### PR TITLE
feat: mint from AToken

### DIFF
--- a/src/contracts/antei/aave/tokens/AnteiAToken.sol
+++ b/src/contracts/antei/aave/tokens/AnteiAToken.sol
@@ -14,6 +14,7 @@ import {IAaveIncentivesController} from '../../dependencies/aave-tokens/interfac
 import {IAnteiAToken} from './interfaces/IAnteiAToken.sol';
 import {ILendingPoolAddressesProvider} from '../../dependencies/aave-core/interfaces/ILendingPoolAddressesProvider.sol';
 import {AnteiVariableDebtToken} from './AnteiVariableDebtToken.sol';
+import {IMintableERC20} from '../../interfaces/IMintableERC20.sol';
 import {IBurnableERC20} from '../../interfaces/IBurnableERC20.sol';
 
 /**
@@ -271,7 +272,7 @@ contract AnteiAToken is VersionedInitializable, IncentivizedERC20, IAnteiAToken 
     onlyLendingPool
     returns (uint256)
   {
-    IERC20(UNDERLYING_ASSET_ADDRESS).transfer(target, amount);
+    IMintableERC20(UNDERLYING_ASSET_ADDRESS).mint(target, amount);
     return amount;
   }
 

--- a/src/contracts/antei/aave/tokens/AnteiVariableDebtToken.sol
+++ b/src/contracts/antei/aave/tokens/AnteiVariableDebtToken.sol
@@ -6,7 +6,6 @@ import {Errors} from '../../dependencies/aave-core/protocol/libraries/helpers/Er
 import {IAaveIncentivesController} from '../../dependencies/aave-tokens/interfaces/IAaveIncentivesController.sol';
 
 // Antei Imports
-import {IMintableERC20} from '../../interfaces/IMintableERC20.sol';
 import {ILendingPoolAddressesProvider} from '../../dependencies/aave-core/interfaces/ILendingPoolAddressesProvider.sol';
 import {IAnteiVariableDebtToken} from './interfaces/IAnteiVariableDebtToken.sol';
 import {AnteiDebtTokenBase} from './base/AnteiDebtTokenBase.sol';
@@ -100,7 +99,6 @@ contract AnteiVariableDebtToken is AnteiDebtTokenBase, IAnteiVariableDebtToken {
     _balanceFromInterest[onBehalfOf] = _balanceFromInterest[onBehalfOf].add(balanceIncrease);
 
     _mint(onBehalfOf, amountScaled);
-    IMintableERC20(UNDERLYING_ASSET_ADDRESS).mint(address(_anteiAToken), amount);
 
     emit Transfer(address(0), onBehalfOf, amount);
     emit Mint(user, onBehalfOf, amount, index);

--- a/src/tasks/setup/add-asd-as-entity.ts
+++ b/src/tasks/setup/add-asd-as-entity.ts
@@ -27,7 +27,7 @@ task('add-asd-as-entity', 'Adds Aave as a asd entity').setAction(async (_, hre) 
     label: asdEntityConfig.label,
     entityAddress: asdEntityConfig.entityAddress,
     mintLimit: asdEntityConfig.mintLimit,
-    minters: [variableDebtToken.address],
+    minters: [aToken.address],
     burners: [aToken.address],
     active: true,
   };

--- a/src/test/initial-entitiy-configuration.test.ts
+++ b/src/test/initial-entitiy-configuration.test.ts
@@ -22,7 +22,7 @@ makeSuite('Initial ASD Aave Entity Configuration', (testEnv: TestEnv) => {
     expect(mintLimit).to.be.equal(asdEntityConfig.mintLimit);
     expect(mintBalance).to.be.equal(0);
     expect(minters.length).to.be.equal(1);
-    expect(minters[0]).to.be.equal(variableDebtToken.address);
+    expect(minters[0]).to.be.equal(aToken.address);
     expect(burners.length).to.be.equal(1);
     expect(burners[0]).to.be.equal(aToken.address);
     expect(active).to.be.true;


### PR DESCRIPTION
Based on the update to ReserveLogic, the AToken no longer needs to hold the underlying asset in order to compute available liquidity. This allows us to skip the step of minting the asd to the AToken prior to transferring it to the user.

Instead, the asd can be minted directly to the user in the `transferUnderlyingTo` function.