### PR TITLE
feat: reduce setup logging

### DIFF
--- a/src/tasks/setup/upgrade-pool.ts
+++ b/src/tasks/setup/upgrade-pool.ts
@@ -23,17 +23,13 @@ task('upgrade-pool', 'Upgrade pool for antei').setAction(async (_, hre) => {
   ).connect(addressesProviderSigner);
 
   let error = false;
-  console.log(`trying to upgrade...`);
+  console.log(`trying to upgrade pool...`);
   const upgradeTx = await poolProxy.upgradeTo(nextPool.address);
-  console.log(`waiting for receipt...`);
   const upgradeTxReceipt = await upgradeTx.wait();
-  console.log(`got receipt receipt...`);
   if (upgradeTxReceipt && upgradeTxReceipt.events) {
     const upgradeEvents = upgradeTxReceipt.events.filter((e) => e.event === 'Upgraded');
     if (upgradeEvents.length > 0 && upgradeEvents[0].args) {
       console.log(`Pool implementation set to: ${upgradeEvents[0].args.implementation}`);
-      console.log(`Previous revision ${previousRevision}`);
-      console.log(`Current revision  ${await nextPool.LENDINGPOOL_REVISION()}`);
     } else {
       error = true;
     }

--- a/src/tasks/setup/upgrade-stkAave.ts
+++ b/src/tasks/setup/upgrade-stkAave.ts
@@ -12,18 +12,6 @@ task('upgrade-stkAave', 'Upgrade Staked Aave').setAction(async (_, hre) => {
   await hre.run('set-DRE');
   const { ethers } = DRE;
 
-  const stkAaveProxyAsStkAave = await getStakedAave(helperAddresses.stkAave);
-
-  const previousRevision = await stkAaveProxyAsStkAave.REVISION();
-  const previousImplementationAsBytes = await ethers.provider.send('eth_getStorageAt', [
-    helperAddresses.stkAave,
-    '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc',
-    'latest',
-  ]);
-  const previousimplementationAddress = ethers.utils.getAddress(
-    ethers.utils.hexDataSlice(previousImplementationAsBytes, 12)
-  );
-
   const newStakedAaveImpl = await ethers.getContract('StakedTokenV2Rev4');
 
   const governanceSigner = await impersonateAccountHardhat(helperAddresses.longExecutor);
@@ -42,7 +30,6 @@ task('upgrade-stkAave', 'Upgrade Staked Aave').setAction(async (_, hre) => {
     anteiVariableDebtTokenAddress,
   ]);
 
-  let error = false;
   console.log(`trying to upgrade stkAave...`);
   const upgradeTx = await stkAaveProxy.upgradeToAndCall(
     newStakedAaveImpl.address,
@@ -54,7 +41,4 @@ task('upgrade-stkAave', 'Upgrade Staked Aave').setAction(async (_, hre) => {
     .withArgs(newStakedAaveImpl.address);
 
   console.log(`StkAave implementation set to: ${newStakedAaveImpl.address}`);
-  console.log(`Previous Implementation: ${previousimplementationAddress}`);
-  console.log(`Previous Revision ${previousRevision}`);
-  console.log(`New Revision ${await stkAaveProxyAsStkAave.REVISION()}`);
 });


### PR DESCRIPTION
Reducing the amount of information logged during setup in the Pool Upgrade and Stk Aave Upgrade.

Only print the address of the new implementation. The tests confirm the upgrades occur as intended.