### PR TITLE
fix: don't ignore all types folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ artifacts/
 node_modules
 
 deployments
-types
+/types

--- a/src/contracts/gho/dependencies/aave-core/protocol/libraries/types/DataTypes.sol
+++ b/src/contracts/gho/dependencies/aave-core/protocol/libraries/types/DataTypes.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity >=0.6.0 <0.9.0;
+
+library DataTypes {
+  // refer to the whitepaper, section 1.1 basic concepts for a formal description of these properties.
+  struct ReserveData {
+    //stores the reserve configuration
+    ReserveConfigurationMap configuration;
+    //the liquidity index. Expressed in ray
+    uint128 liquidityIndex;
+    //variable borrow index. Expressed in ray
+    uint128 variableBorrowIndex;
+    //the current supply rate. Expressed in ray
+    uint128 currentLiquidityRate;
+    //the current variable borrow rate. Expressed in ray
+    uint128 currentVariableBorrowRate;
+    //the current stable borrow rate. Expressed in ray
+    uint128 currentStableBorrowRate;
+    uint40 lastUpdateTimestamp;
+    //tokens addresses
+    address aTokenAddress;
+    address stableDebtTokenAddress;
+    address variableDebtTokenAddress;
+    //address of the interest rate strategy
+    address interestRateStrategyAddress;
+    //the id of the reserve. Represents the position in the list of the active reserves
+    uint8 id;
+  }
+
+  struct ReserveConfigurationMap {
+    //bit 0-15: LTV
+    //bit 16-31: Liq. threshold
+    //bit 32-47: Liq. bonus
+    //bit 48-55: Decimals
+    //bit 56: Reserve is active
+    //bit 57: reserve is frozen
+    //bit 58: borrowing is enabled
+    //bit 59: stable rate borrowing enabled
+    //bit 60-63: reserved
+    //bit 64-79: reserve factor
+    uint256 data;
+  }
+
+  struct UserConfigurationMap {
+    uint256 data;
+  }
+
+  enum InterestRateMode {
+    NONE,
+    STABLE,
+    VARIABLE
+  }
+}


### PR DESCRIPTION
fix gitignore

was ingoring all `types` folders, which included and important dependencies folder.

The only types folder that should be ignored is the base level directory types which contains the auto-generated typscript objects that represent the contracts.