### PR TITLE
fix: remove extra modifier

### DIFF
--- a/src/contracts/facilitators/aave/tokens/GhoAToken.sol
+++ b/src/contracts/facilitators/aave/tokens/GhoAToken.sol
@@ -99,7 +99,7 @@ contract GhoAToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base
     address onBehalfOf,
     uint256 amount,
     uint256 index
-  ) external virtual override onlyPool returns (bool) {
+  ) external virtual override returns (bool) {
     revert('OPERATION_NOT_PERMITTED');
   }
 
@@ -109,12 +109,12 @@ contract GhoAToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base
     address receiverOfUnderlying,
     uint256 amount,
     uint256 index
-  ) external virtual override onlyPool {
+  ) external virtual override {
     revert('OPERATION_NOT_PERMITTED');
   }
 
   /// @inheritdoc IAToken
-  function mintToTreasury(uint256 amount, uint256 index) external override onlyPool {
+  function mintToTreasury(uint256 amount, uint256 index) external override {
     revert('OPERATION_NOT_PERMITTED');
   }
 
@@ -123,7 +123,7 @@ contract GhoAToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base
     address from,
     address to,
     uint256 value
-  ) external override onlyPool {
+  ) external override {
     revert('OPERATION_NOT_PERMITTED');
   }
 

--- a/src/test/gho-atoken.test.ts
+++ b/src/test/gho-atoken.test.ts
@@ -55,15 +55,15 @@ makeSuite('Gho AToken End-To-End', (testEnv: TestEnv) => {
     ).to.be.revertedWith('OPERATION_NOT_PERMITTED');
   });
 
-  it('Mint AToken - not permissioned (revert expected)', async function () {
+  it('Mint AToken - operation not permitted (revert expected)', async function () {
     const { aToken, users } = testEnv;
 
     await expect(
       aToken.connect(users[5].signer).mint(testAddressOne, testAddressOne, 1000, 1)
-    ).to.be.revertedWith(CALLER_MUST_BE_POOL);
+    ).to.be.revertedWith('OPERATION_NOT_PERMITTED');
   });
 
-  it('Mint AToken - no minting allowed (revert expected)', async function () {
+  it('Mint AToken - operation not permitted (revert expected)', async function () {
     const { aToken } = testEnv;
 
     await expect(
@@ -71,15 +71,15 @@ makeSuite('Gho AToken End-To-End', (testEnv: TestEnv) => {
     ).to.be.revertedWith('OPERATION_NOT_PERMITTED');
   });
 
-  it('Burn AToken - not permissioned (revert expected)', async function () {
+  it('Burn AToken - operation not permitted (revert expected)', async function () {
     const { aToken, users } = testEnv;
 
     await expect(
       aToken.connect(users[5].signer).burn(testAddressOne, testAddressOne, 1000, 1)
-    ).to.be.revertedWith(CALLER_MUST_BE_POOL);
+    ).to.be.revertedWith('OPERATION_NOT_PERMITTED');
   });
 
-  it('Burn AToken - no burning allowed (revert expected)', async function () {
+  it('Burn AToken - operation not permitted (revert expected)', async function () {
     const { aToken } = testEnv;
 
     await expect(
@@ -129,5 +129,19 @@ makeSuite('Gho AToken End-To-End', (testEnv: TestEnv) => {
     const { aToken } = testEnv;
 
     await expect(await aToken.totalSupply()).to.be.equal(0);
+  });
+
+  it('MintToTreasury - operation not permitted(revert expected)', async function () {
+    const { aToken } = testEnv;
+
+    await expect(aToken.mintToTreasury(10000, 1)).to.be.revertedWith('OPERATION_NOT_PERMITTED');
+  });
+
+  it('TransferOnLiquidation - operation not permitted (revert expected)', async function () {
+    const { users, aToken } = testEnv;
+
+    await expect(
+      aToken.transferOnLiquidation(users[0].address, users[1].address, 100)
+    ).to.be.revertedWith('OPERATION_NOT_PERMITTED');
   });
 });


### PR DESCRIPTION
closes #154

remove the `onlyPool` modifier on functions that revert with "OPERATION_NOT_PERMITTED"