### PR TITLE
fix: Avoid discount refresh on self-transfer stkAave

### DIFF
--- a/src/contracts/facilitators/aave/tokens/GhoVariableDebtToken.sol
+++ b/src/contracts/facilitators/aave/tokens/GhoVariableDebtToken.sol
@@ -298,7 +298,7 @@ contract GhoVariableDebtToken is DebtTokenBase, ScaledBalanceTokenBase, IGhoVari
       emit Mint(address(0), sender, balanceIncrease, balanceIncrease, index);
     }
 
-    if (recipientPreviousScaledBalance > 0) {
+    if (sender != recipient && recipientPreviousScaledBalance > 0) {
       (balanceIncrease, discountScaled) = _accrueDebtOnAction(
         recipient,
         recipientPreviousScaledBalance,


### PR DESCRIPTION
Self-transfers of stkAave lead to unnecessary emission of events