### PR TITLE
fix: Simplify logic of discount percent refresh in GhoDebtToken

### DIFF
--- a/src/contracts/facilitators/aave/tokens/GhoVariableDebtToken.sol
+++ b/src/contracts/facilitators/aave/tokens/GhoVariableDebtToken.sol
@@ -298,7 +298,7 @@ contract GhoVariableDebtToken is DebtTokenBase, ScaledBalanceTokenBase, IGhoVari
       emit Mint(address(0), sender, balanceIncrease, balanceIncrease, index);
     }
 
-    if (sender != recipient && recipientPreviousScaledBalance > 0) {
+    if (recipientPreviousScaledBalance > 0) {
       (balanceIncrease, discountScaled) = _accrueDebtOnAction(
         recipient,
         recipientPreviousScaledBalance,


### PR DESCRIPTION
We were using an unnecessary bool variable to detect if the discount percent of the user changed.