### PR TITLE
fix: Emit the previous discount percent of the user for tracking

### DIFF
--- a/src/contracts/facilitators/aave/tokens/GhoVariableDebtToken.sol
+++ b/src/contracts/facilitators/aave/tokens/GhoVariableDebtToken.sol
@@ -545,11 +545,16 @@ contract GhoVariableDebtToken is DebtTokenBase, ScaledBalanceTokenBase, IGhoVari
     if (newDiscountPercent != 0) {
       uint40 newRebalanceTimestamp = uint40(block.timestamp + _discountLockPeriod);
       _ghoUserState[user].rebalanceTimestamp = newRebalanceTimestamp;
-      emit DiscountPercentLocked(user, newDiscountPercent, newRebalanceTimestamp);
+      emit DiscountPercentLocked(
+        user,
+        previousDiscountPercent,
+        newDiscountPercent,
+        newRebalanceTimestamp
+      );
     } else {
       if (changed) {
         _ghoUserState[user].rebalanceTimestamp = 0;
-        emit DiscountPercentLocked(user, 0, 0);
+        emit DiscountPercentLocked(user, previousDiscountPercent, 0, 0);
       }
     }
   }

--- a/src/contracts/facilitators/aave/tokens/interfaces/IGhoVariableDebtToken.sol
+++ b/src/contracts/facilitators/aave/tokens/interfaces/IGhoVariableDebtToken.sol
@@ -44,12 +44,14 @@ interface IGhoVariableDebtToken is IVariableDebtToken {
   /**
    * @dev Emitted when a user's discount or rebalanceTimestamp is updated
    * @param user The address of the user
-   * @param discountPercent The discount percent of the user
+   * @param oldDiscountPercent The old discount percent of the user
+   * @param newDiscountPercent The new discount percent of the user
    * @param rebalanceTimestamp Timestamp when a users locked discount can be rebalanced
    */
   event DiscountPercentLocked(
     address indexed user,
-    uint256 indexed discountPercent,
+    uint256 oldDiscountPercent,
+    uint256 indexed newDiscountPercent,
     uint256 indexed rebalanceTimestamp
   );
 

--- a/src/test/discount-borrow.test.ts
+++ b/src/test/discount-borrow.test.ts
@@ -100,6 +100,8 @@ makeSuite('Gho Discount Borrow Flow', (testEnv: TestEnv) => {
     const { lastUpdateTimestamp: ghoLastUpdateTimestamp, variableBorrowIndex } =
       await pool.getReserveData(gho.address);
 
+    const discountPercentBefore = await variableDebtToken.getDiscountPercent(users[1].address);
+
     await weth.connect(users[1].signer).approve(pool.address, collateralAmount);
     await pool
       .connect(users[1].signer)
@@ -134,6 +136,7 @@ makeSuite('Gho Discount Borrow Flow', (testEnv: TestEnv) => {
       .to.emit(variableDebtToken, 'DiscountPercentLocked')
       .withArgs(
         users[1].address,
+        discountPercentBefore,
         discountPercent,
         txTimestamp.add(ghoReserveConfig.DISCOUNT_LOCK_PERIOD)
       );
@@ -267,7 +270,7 @@ makeSuite('Gho Discount Borrow Flow', (testEnv: TestEnv) => {
       .to.emit(variableDebtToken, 'Burn')
       .withArgs(users[1].address, ZERO_ADDRESS, borrowAmount, user2ExpectedInterest, expIndex)
       .to.emit(variableDebtToken, 'DiscountPercentLocked')
-      .withArgs(users[1].address, user2DiscountPercent, 0);
+      .withArgs(users[1].address, user2DiscountPercentBefore, user2DiscountPercent, 0);
 
     const user1Debt = await variableDebtToken.balanceOf(users[0].address);
     const user2Debt = await variableDebtToken.balanceOf(users[1].address);


### PR DESCRIPTION
It is not possible to keep track of the discounts that users are enjoying.

At this moment there is no specific event for the amount discounted off the debt interest and it's not possible to calculate if based on others.

A way to calculate it would be using the `balanceIncrease` value (of the Mint/Burn event) and the `discountPercent` value that the user was enjoying until the moment of the action:

`(balanceIncrease * 100) / discountPercent = discountAmount`

 