### PR TITLE
fix: Rename event for bucket level update for clarity and consistency

### DIFF
--- a/src/contracts/gho/GhoToken.sol
+++ b/src/contracts/gho/GhoToken.sol
@@ -38,7 +38,7 @@ contract GhoToken is ERC20, Ownable, IGhoToken {
     require(bucketCapacity >= newBucketLevel, 'FACILITATOR_BUCKET_CAPACITY_EXCEEDED');
     _facilitators[msg.sender].bucketLevel = uint128(newBucketLevel);
 
-    emit BucketLevelChanged(msg.sender, currentBucketLevel, newBucketLevel);
+    emit FacilitatorBucketLevelUpdated(msg.sender, currentBucketLevel, newBucketLevel);
     _mint(account, amount);
   }
 
@@ -53,7 +53,7 @@ contract GhoToken is ERC20, Ownable, IGhoToken {
     uint256 currentBucketLevel = _facilitators[msg.sender].bucketLevel;
     uint256 newBucketLevel = currentBucketLevel - amount;
     _facilitators[msg.sender].bucketLevel = uint128(newBucketLevel);
-    emit BucketLevelChanged(msg.sender, currentBucketLevel, newBucketLevel);
+    emit FacilitatorBucketLevelUpdated(msg.sender, currentBucketLevel, newBucketLevel);
     _burn(msg.sender, amount);
   }
 

--- a/src/contracts/gho/interfaces/IGhoToken.sol
+++ b/src/contracts/gho/interfaces/IGhoToken.sol
@@ -52,7 +52,11 @@ interface IGhoToken is IERC20Burnable, IERC20Mintable, IERC20 {
    * @param oldLevel The old level of the bucket
    * @param newLevel The new level of the bucket
    */
-  event BucketLevelChanged(address indexed facilitatorAddress, uint256 oldLevel, uint256 newLevel);
+  event FacilitatorBucketLevelUpdated(
+    address indexed facilitatorAddress,
+    uint256 oldLevel,
+    uint256 newLevel
+  );
 
   /**
    * @notice Add the facilitator passed with the parameters to the facilitators list.

--- a/src/test/unitTests/gho-token-unit.test.ts
+++ b/src/test/unitTests/gho-token-unit.test.ts
@@ -181,7 +181,7 @@ describe('GhoToken Unit Test', () => {
     await expect(ghoToken.connect(facilitator1.signer).mint(facilitator1.address, mintAmount))
       .to.emit(ghoToken, 'Transfer')
       .withArgs(ZERO_ADDRESS, facilitator1.address, mintAmount)
-      .to.emit(ghoToken, 'BucketLevelChanged')
+      .to.emit(ghoToken, 'FacilitatorBucketLevelUpdated')
       .withArgs(facilitator1.address, 0, mintAmount);
 
     const [, level] = await ghoToken.getFacilitatorBucket(facilitator1.address);
@@ -194,7 +194,7 @@ describe('GhoToken Unit Test', () => {
     await expect(ghoToken.connect(facilitator2.signer).mint(facilitator2.address, mintAmount))
       .to.emit(ghoToken, 'Transfer')
       .withArgs(ZERO_ADDRESS, facilitator2.address, mintAmount)
-      .to.emit(ghoToken, 'BucketLevelChanged')
+      .to.emit(ghoToken, 'FacilitatorBucketLevelUpdated')
       .withArgs(facilitator2.address, 0, mintAmount);
 
     const [, level] = await ghoToken.getFacilitatorBucket(facilitator2.address);
@@ -222,7 +222,7 @@ describe('GhoToken Unit Test', () => {
     await expect(ghoToken.connect(facilitator1.signer).burn(burnAmount))
       .to.emit(ghoToken, 'Transfer')
       .withArgs(facilitator1.address, ZERO_ADDRESS, burnAmount)
-      .to.emit(ghoToken, 'BucketLevelChanged')
+      .to.emit(ghoToken, 'FacilitatorBucketLevelUpdated')
       .withArgs(facilitator1.address, previouslyMinted, previouslyMinted.sub(burnAmount));
 
     const [, level] = await ghoToken.getFacilitatorBucket(facilitator1.address);
@@ -237,7 +237,7 @@ describe('GhoToken Unit Test', () => {
     await expect(ghoToken.connect(facilitator2.signer).burn(burnAmount))
       .to.emit(ghoToken, 'Transfer')
       .withArgs(facilitator2.address, ZERO_ADDRESS, burnAmount)
-      .to.emit(ghoToken, 'BucketLevelChanged')
+      .to.emit(ghoToken, 'FacilitatorBucketLevelUpdated')
       .withArgs(facilitator2.address, previouslyMinted, previouslyMinted.sub(burnAmount));
 
     const [, level] = await ghoToken.getFacilitatorBucket(facilitator2.address);
@@ -289,7 +289,7 @@ describe('GhoToken Unit Test', () => {
     await expect(ghoToken.connect(facilitator1.signer).mint(facilitator1.address, mintAmount))
       .to.emit(ghoToken, 'Transfer')
       .withArgs(ZERO_ADDRESS, facilitator1.address, mintAmount)
-      .to.emit(ghoToken, 'BucketLevelChanged')
+      .to.emit(ghoToken, 'FacilitatorBucketLevelUpdated')
       .withArgs(facilitator1.address, 0, mintAmount);
 
     const [, level] = await ghoToken.getFacilitatorBucket(facilitator1.address);


### PR DESCRIPTION
Having `FacilitatorBucketCapacityUpdated` and `BucketLevelChanged` feels inconsistent 