### PR TITLE
fix: User rayDiv over plain div for discountScaled calc

### DIFF
--- a/src/contracts/facilitators/aave/tokens/GhoVariableDebtToken.sol
+++ b/src/contracts/facilitators/aave/tokens/GhoVariableDebtToken.sol
@@ -501,12 +501,7 @@ contract GhoVariableDebtToken is DebtTokenBase, ScaledBalanceTokenBase, IGhoVari
     uint256 discountScaled = 0;
     if (balanceIncrease != 0 && discountPercent != 0) {
       uint256 discount = balanceIncrease.percentMul(discountPercent);
-
-      // skip checked division to
-      // avoid rounding in the case discount = 100%
-      // The index will never be 0
-      discountScaled = (discount * WadRayMath.RAY) / index;
-
+      discountScaled = discount.rayDiv(index);
       balanceIncrease = balanceIncrease - discount;
     }
 


### PR DESCRIPTION
Closed #231 

The original intention of using `/` instead of `rayDiv` was optimizing (`index` won't never be 0). However, native math operations rounds down and the rest of the math operations are rounding up. Changing it so it's aligned to the rest of the calculations.