### PR TITLE
misc: Adapt maxFlashLoan to EIP3156 Standard

### DIFF
--- a/src/contracts/facilitators/flashMinter/GhoFlashMinter.sol
+++ b/src/contracts/facilitators/flashMinter/GhoFlashMinter.sol
@@ -77,7 +77,9 @@ contract GhoFlashMinter is IGhoFlashMinter {
       return 0;
     } else {
       IGhoToken.Facilitator memory flashMinterFacilitator = GHO_TOKEN.getFacilitator(address(this));
-      return flashMinterFacilitator.bucketCapacity - flashMinterFacilitator.bucketLevel;
+      uint256 capacity = flashMinterFacilitator.bucketCapacity;
+      uint256 level = flashMinterFacilitator.bucketLevel;
+      return capacity > level ? capacity - level : 0;
     }
   }
 


### PR DESCRIPTION
Closes #230

This PR simply returns zero on a call to maxFlashLoan() when the bucket level exceeds the capacity.