### PR TITLE
fix: Revert change of maxflashloan

### DIFF
--- a/src/contracts/facilitators/flashMinter/GhoFlashMinter.sol
+++ b/src/contracts/facilitators/flashMinter/GhoFlashMinter.sol
@@ -77,9 +77,7 @@ contract GhoFlashMinter is IGhoFlashMinter {
       return 0;
     } else {
       IGhoToken.Facilitator memory flashMinterFacilitator = GHO_TOKEN.getFacilitator(address(this));
-      uint256 capacity = flashMinterFacilitator.bucketCapacity;
-      uint256 level = flashMinterFacilitator.bucketLevel;
-      return capacity > level ? capacity - level : 0;
+      return flashMinterFacilitator.bucketCapacity - flashMinterFacilitator.bucketLevel;
     }
   }
 


### PR DESCRIPTION
Reverting change of #233 about issue #230 

There is not need to check if `level` is higher than `capacity` because bucket's level will be always be lower or equal than its capacity.

Even in the middle of a flashmint execution, the invariant is met: `bucketCapacity >= bucketLevel`