### PR TITLE
test: Fix Event Tests

### DIFF
--- a/src/test/basic-borrow.test.ts
+++ b/src/test/basic-borrow.test.ts
@@ -38,7 +38,7 @@ makeSuite('Gho Basic Borrow Flow', (testEnv: TestEnv) => {
       .connect(users[0].signer)
       .borrow(gho.address, borrowAmount, 2, 0, users[0].address);
 
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(ZERO_ADDRESS, users[0].address, borrowAmount)
       .to.emit(variableDebtToken, 'Mint')
@@ -103,7 +103,7 @@ makeSuite('Gho Basic Borrow Flow', (testEnv: TestEnv) => {
     );
     const expIndex = variableBorrowIndex.rayMul(multiplier);
 
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(ZERO_ADDRESS, users[1].address, borrowAmount)
       .to.emit(variableDebtToken, 'Mint')
@@ -147,7 +147,7 @@ makeSuite('Gho Basic Borrow Flow', (testEnv: TestEnv) => {
     const amount = user1ExpectedBalance.sub(borrowAmount);
     const user1ExpectedBalanceIncrease = amount.sub(borrowAmount);
 
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(ZERO_ADDRESS, users[0].address, amount)
       .to.emit(variableDebtToken, 'Mint')
@@ -195,7 +195,7 @@ makeSuite('Gho Basic Borrow Flow', (testEnv: TestEnv) => {
     const user2ExpectedBalance = user2ScaledBefore.rayMul(expIndex);
     const user2ExpectedInterest = user2ExpectedBalance.sub(borrowAmount);
 
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(users[1].address, ZERO_ADDRESS, borrowAmount)
       .to.emit(variableDebtToken, 'Burn')
@@ -240,7 +240,7 @@ makeSuite('Gho Basic Borrow Flow', (testEnv: TestEnv) => {
     );
     const expIndex = variableBorrowIndex.rayMul(multiplier);
 
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(ZERO_ADDRESS, users[2].address, borrowAmount.mul(3))
       .to.emit(variableDebtToken, 'Mint')
@@ -284,7 +284,7 @@ makeSuite('Gho Basic Borrow Flow', (testEnv: TestEnv) => {
     const expectedATokenGhoBalance = aTokenGhoBalanceBefore.add(repayAmount);
 
     const amount = user1ExpectedBalanceIncrease.sub(repayAmount);
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(ZERO_ADDRESS, users[0].address, amount)
       .to.emit(variableDebtToken, 'Mint')
@@ -333,7 +333,7 @@ makeSuite('Gho Basic Borrow Flow', (testEnv: TestEnv) => {
     const expectedATokenGhoBalance = aTokenGhoBalanceBefore.add(user1ExpectedInterest);
 
     const amount = user1ExpectedBalance.sub(user1ExpectedBalanceIncrease);
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(users[0].address, ZERO_ADDRESS, amount)
       .to.emit(variableDebtToken, 'Burn')
@@ -356,7 +356,7 @@ makeSuite('Gho Basic Borrow Flow', (testEnv: TestEnv) => {
 
     const tx = await aToken.distributeFeesToTreasury();
 
-    expect(tx)
+    await expect(tx)
       .to.emit(aToken, 'FeesDistributedToTreasury')
       .withArgs(treasuryAddress, gho.address, aTokenBalance);
 

--- a/src/test/borrow-onBehalf.test.ts
+++ b/src/test/borrow-onBehalf.test.ts
@@ -39,7 +39,7 @@ makeSuite('Gho OnBehalf Borrow Flow', (testEnv: TestEnv) => {
       .connect(users[0].signer)
       .approveDelegation(users[1].address, borrowAmount);
 
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'BorrowAllowanceDelegated')
       .withArgs(users[0].address, users[1].address, gho.address, borrowAmount);
   });
@@ -51,7 +51,7 @@ makeSuite('Gho OnBehalf Borrow Flow', (testEnv: TestEnv) => {
       .connect(users[1].signer)
       .borrow(gho.address, borrowAmount, 2, 0, users[0].address);
 
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(ZERO_ADDRESS, users[0].address, borrowAmount)
       .to.emit(variableDebtToken, 'Mint')
@@ -114,7 +114,7 @@ makeSuite('Gho OnBehalf Borrow Flow', (testEnv: TestEnv) => {
     );
     const expIndex = variableBorrowIndex.rayMul(multiplier);
 
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(ZERO_ADDRESS, users[2].address, borrowAmount)
       .to.emit(variableDebtToken, 'Mint')
@@ -159,7 +159,7 @@ makeSuite('Gho OnBehalf Borrow Flow', (testEnv: TestEnv) => {
       .repay(gho.address, user1ExpectedBalance, 2, users[0].address);
     rcpt = await tx.wait();
 
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(users[0].address, ZERO_ADDRESS, borrowAmount)
       .to.emit(variableDebtToken, 'Burn')

--- a/src/test/discount-borrow.test.ts
+++ b/src/test/discount-borrow.test.ts
@@ -57,7 +57,7 @@ makeSuite('Gho Discount Borrow Flow', (testEnv: TestEnv) => {
       .connect(users[0].signer)
       .borrow(gho.address, borrowAmount, 2, 0, users[0].address);
 
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(ZERO_ADDRESS, users[0].address, borrowAmount)
       .to.emit(variableDebtToken, 'Mint')
@@ -132,7 +132,7 @@ makeSuite('Gho Discount Borrow Flow', (testEnv: TestEnv) => {
       discountTokenBalance
     );
 
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(ZERO_ADDRESS, users[1].address, borrowAmount)
       .to.emit(variableDebtToken, 'Mint')
@@ -231,7 +231,7 @@ makeSuite('Gho Discount Borrow Flow', (testEnv: TestEnv) => {
       .div(PERCENTAGE_FACTOR);
     const user2ExpectedBalance = user2ExpectedBalanceNoDiscount.sub(user2ExpectedDiscount);
 
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(ZERO_ADDRESS, users[0].address, amount)
       .to.emit(variableDebtToken, 'Mint')
@@ -301,7 +301,7 @@ makeSuite('Gho Discount Borrow Flow', (testEnv: TestEnv) => {
       user2DiscountTokenBalance
     );
 
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(users[1].address, ZERO_ADDRESS, borrowAmount)
       .to.emit(variableDebtToken, 'Burn')
@@ -353,7 +353,7 @@ makeSuite('Gho Discount Borrow Flow', (testEnv: TestEnv) => {
     );
     const expIndex = variableBorrowIndex.rayMul(multiplier);
 
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(ZERO_ADDRESS, users[2].address, borrowAmount.mul(3))
       .to.emit(variableDebtToken, 'Mint')
@@ -399,7 +399,7 @@ makeSuite('Gho Discount Borrow Flow', (testEnv: TestEnv) => {
     const expectedATokenGhoBalance = aTokenGhoBalanceBefore.add(repayAmount);
 
     const amount = user1ExpectedBalanceIncrease.sub(repayAmount);
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(ZERO_ADDRESS, users[0].address, amount)
       .to.emit(variableDebtToken, 'Mint')
@@ -450,7 +450,7 @@ makeSuite('Gho Discount Borrow Flow', (testEnv: TestEnv) => {
     const expectedATokenGhoBalance = aTokenGhoBalanceBefore.add(user1ExpectedInterest);
 
     const amount = user1ExpectedBalance.sub(user1ExpectedBalanceIncrease);
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(users[0].address, ZERO_ADDRESS, amount)
       .to.emit(variableDebtToken, 'Burn')
@@ -475,7 +475,7 @@ makeSuite('Gho Discount Borrow Flow', (testEnv: TestEnv) => {
 
     const tx = await aToken.distributeFeesToTreasury();
 
-    expect(tx)
+    await expect(tx)
       .to.emit(aToken, 'FeesDistributedToTreasury')
       .withArgs(treasuryAddress, gho.address, aTokenBalance);
 

--- a/src/test/discount-rebalance.test.ts
+++ b/src/test/discount-rebalance.test.ts
@@ -68,7 +68,7 @@ makeSuite('Gho Discount Rebalance Flow', (testEnv: TestEnv) => {
       discountTokenBalance
     );
 
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(ZERO_ADDRESS, users[0].address, borrowAmount)
       .to.emit(variableDebtToken, 'Mint')
@@ -134,7 +134,7 @@ makeSuite('Gho Discount Rebalance Flow', (testEnv: TestEnv) => {
       discountTokenBalance
     );
 
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'Transfer')
       .withArgs(ZERO_ADDRESS, users[1].address, borrowAmount)
       .to.emit(variableDebtToken, 'Mint')
@@ -195,7 +195,7 @@ makeSuite('Gho Discount Rebalance Flow', (testEnv: TestEnv) => {
       user1DiscountTokenBalance
     );
 
-    expect(tx)
+    await expect(tx)
       .to.emit(variableDebtToken, 'DiscountPercentLocked')
       .withArgs(
         users[0].address,
@@ -232,8 +232,8 @@ makeSuite('Gho Discount Rebalance Flow', (testEnv: TestEnv) => {
     const oldDiscountRateStrategyAddress = await variableDebtToken.getDiscountRateStrategy();
 
     const emptyStrategy = await new EmptyDiscountRateStrategy__factory(poolAdmin.signer).deploy();
-    expect(
-      await variableDebtToken
+    await expect(
+       variableDebtToken
         .connect(poolAdmin.signer)
         .updateDiscountRateStrategy(emptyStrategy.address)
     )
@@ -246,8 +246,8 @@ makeSuite('Gho Discount Rebalance Flow', (testEnv: TestEnv) => {
 
     const discountPercentBefore = await variableDebtToken.getDiscountPercent(users[0].address);
 
-    expect(
-      await variableDebtToken
+    await expect(
+       variableDebtToken
         .connect(users[2].signer)
         .rebalanceUserDiscountPercent(users[0].address)
     )

--- a/src/test/flashmint.test.ts
+++ b/src/test/flashmint.test.ts
@@ -116,7 +116,7 @@ makeSuite('Gho FlashMinter', (testEnv: TestEnv) => {
 
     tx = await flashBorrower.flashBorrow(gho.address, borrowAmount);
 
-    expect(tx)
+    await expect(tx)
       .to.emit(flashMinter, 'FlashMint')
       .withArgs(
         flashBorrower.address,
@@ -145,7 +145,7 @@ makeSuite('Gho FlashMinter', (testEnv: TestEnv) => {
     const borrowAmount = ethers.utils.parseUnits('1000.0', 18);
     tx = await flashBorrower.flashBorrow(gho.address, borrowAmount);
 
-    expect(tx)
+    await expect(tx)
       .to.emit(flashMinter, 'FlashMint')
       .withArgs(
         flashBorrower.address,
@@ -232,7 +232,7 @@ makeSuite('Gho FlashMinter', (testEnv: TestEnv) => {
 
     tx = await flashBorrower.flashBorrow(gho.address, capacityMinusOne);
 
-    expect(tx)
+    await expect(tx)
       .to.emit(flashMinter, 'FlashMint')
       .withArgs(
         flashBorrower.address,
@@ -284,7 +284,7 @@ makeSuite('Gho FlashMinter', (testEnv: TestEnv) => {
 
     tx = await flashBorrower.flashBorrow(gho.address, capacity);
 
-    expect(tx)
+    await expect(tx)
       .to.emit(flashMinter, 'FlashMint')
       .withArgs(flashBorrower.address, flashBorrower.address, gho.address, capacity, expectedFee);
 
@@ -369,7 +369,7 @@ makeSuite('Gho FlashMinter', (testEnv: TestEnv) => {
 
     tx = await flashBorrower.flashBorrow(gho.address, capacity);
 
-    expect(tx)
+    await expect(tx)
       .to.emit(flashMinter, 'FlashMint')
       .withArgs(flashBorrower.address, flashBorrower.address, gho.address, capacity, expectedFee);
 
@@ -422,7 +422,7 @@ makeSuite('Gho FlashMinter', (testEnv: TestEnv) => {
 
     const tx = await flashMinter.distributeFeesToTreasury();
 
-    expect(tx)
+    await expect(tx)
       .to.emit(flashMinter, 'FeesDistributedToTreasury')
       .withArgs(treasuryAddress, gho.address, flashMinterBalance);
 
@@ -436,7 +436,7 @@ makeSuite('Gho FlashMinter', (testEnv: TestEnv) => {
     const newFlashFee = 200;
 
     tx = await flashMinter.connect(poolAdmin.signer).updateFee(newFlashFee);
-    expect(tx).to.emit(flashMinter, 'FeeUpdated').withArgs(flashFee, newFlashFee);
+    await expect(tx).to.emit(flashMinter, 'FeeUpdated').withArgs(flashFee, newFlashFee);
   });
 
   it('Check MaxFee amount', async function () {

--- a/src/test/unitTests/gho-token-permit.test.ts
+++ b/src/test/unitTests/gho-token-permit.test.ts
@@ -58,8 +58,8 @@ describe('GhoToken Unit Test', () => {
 
     const labelHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(facilitator1Label));
 
-    expect(
-      await ghoToken
+    await expect(
+       ghoToken
         .connect(users[0].signer)
         .addFacilitator(facilitator1.address, facilitator1Config)
     )

--- a/src/test/unitTests/gho-token-unit.test.ts
+++ b/src/test/unitTests/gho-token-unit.test.ts
@@ -139,7 +139,7 @@ describe('GhoToken Unit Test', () => {
       .connect(users[0].signer)
       .addFacilitator(facilitator1.address, facilitator1Config);
 
-    expect(addFacilitatorTx)
+    await expect(addFacilitatorTx)
       .to.emit(ghoToken, 'FacilitatorAdded')
       .withArgs(facilitator1.address, labelHash, facilitator1Cap);
 


### PR DESCRIPTION
This PR simply addresses and fixes event checking tests to use the proper asynchronous `await` syntax.

Closes #263 