### PR TITLE
fix: Import and reuse error codes at test suite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "@aave/gho",
       "dependencies": {
         "@aave/aave-token": "^1.0.4",
-        "@aave/core-v3": "^1.17.1",
+        "@aave/core-v3": "^1.17.2",
         "@aave/deploy-v3": "^1.55.3",
         "@aave/periphery-v3": "^2.0.0",
         "@aave/safety-module": "^1.0.3",
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@aave/core-v3": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@aave/core-v3/-/core-v3-1.17.1.tgz",
-      "integrity": "sha512-OAHtclfz4LvHDF5Sh2RUfBtOHkEXe0r9xocrAv+3XSiH3hkSh/tzwxdiKGQimqFHR1fyULiVvuOjp6Q5yK4r8A==",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/@aave/core-v3/-/core-v3-1.17.2.tgz",
+      "integrity": "sha512-ztCyKTALoeOQy6MlWVRCvHgilh6vT+d6lwjXhIsmlEYlA0v3L6dQBIyTFIzHBUfcpEjs0T3tSmcVxGY+GAUZ1g==",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -10529,9 +10529,9 @@
       }
     },
     "@aave/core-v3": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@aave/core-v3/-/core-v3-1.17.1.tgz",
-      "integrity": "sha512-OAHtclfz4LvHDF5Sh2RUfBtOHkEXe0r9xocrAv+3XSiH3hkSh/tzwxdiKGQimqFHR1fyULiVvuOjp6Q5yK4r8A=="
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/@aave/core-v3/-/core-v3-1.17.2.tgz",
+      "integrity": "sha512-ztCyKTALoeOQy6MlWVRCvHgilh6vT+d6lwjXhIsmlEYlA0v3L6dQBIyTFIzHBUfcpEjs0T3tSmcVxGY+GAUZ1g=="
     },
     "@aave/deploy-v3": {
       "version": "1.55.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@aave/aave-token": "^1.0.4",
-    "@aave/core-v3": "^1.17.1",
+    "@aave/core-v3": "^1.17.2",
     "@aave/deploy-v3": "^1.55.3",
     "@aave/periphery-v3": "^2.0.0",
     "@aave/safety-module": "^1.0.3",

--- a/src/test/gho-atoken.test.ts
+++ b/src/test/gho-atoken.test.ts
@@ -4,6 +4,8 @@ import { impersonateAccountHardhat } from '../helpers/misc-utils';
 import { makeSuite, TestEnv } from './helpers/make-suite';
 import { ONE_ADDRESS, ZERO_ADDRESS } from '../helpers/constants';
 import { GhoAToken__factory } from '../../types';
+import { ProtocolErrors } from '@aave/core-v3';
+import { INITIALIZED, ZERO_ADDRESS_NOT_VALID } from './helpers/constants';
 
 makeSuite('Gho AToken End-To-End', (testEnv: TestEnv) => {
   let ethers;
@@ -12,14 +14,6 @@ makeSuite('Gho AToken End-To-End', (testEnv: TestEnv) => {
   const testAddressTwo = '0x6fC355D4e0EE44b292E50878F49798ff755A5bbC';
 
   let poolSigner;
-
-  const CALLER_MUST_BE_POOL = '23';
-  const CALLER_NOT_POOL_ADMIN = '1';
-  const OPERATION_NOT_SUPPORTED = '80';
-  const UNDERLYING_CANNOT_BE_RESCUED = '85';
-  const POOL_ADDRESSES_DO_NOT_MATCH = '87';
-  const INITIALIZED = 'Contract instance has already been initialized';
-  const ZERO_ADDRESS_NOT_VALID = 'ZERO_ADDRESS_NOT_VALID';
 
   before(async () => {
     ethers = hre.ethers;
@@ -59,7 +53,7 @@ makeSuite('Gho AToken End-To-End', (testEnv: TestEnv) => {
         'test',
         []
       )
-    ).to.be.revertedWith(POOL_ADDRESSES_DO_NOT_MATCH);
+    ).to.be.revertedWith(ProtocolErrors.POOL_ADDRESSES_DO_NOT_MATCH);
   });
 
   it('Checks initial parameters', async function () {
@@ -99,7 +93,7 @@ makeSuite('Gho AToken End-To-End', (testEnv: TestEnv) => {
     ];
     for (const call of calls) {
       await expect(aToken.connect(nonPoolAdmin.signer)[call.fn](...call.args)).to.be.revertedWith(
-        CALLER_MUST_BE_POOL
+        ProtocolErrors.CALLER_MUST_BE_POOL
       );
     }
   });
@@ -117,7 +111,7 @@ makeSuite('Gho AToken End-To-End', (testEnv: TestEnv) => {
     ];
     for (const call of calls) {
       await expect(aToken.connect(nonPoolAdmin.signer)[call.fn](...call.args)).to.be.revertedWith(
-        CALLER_NOT_POOL_ADMIN
+        ProtocolErrors.CALLER_NOT_POOL_ADMIN
       );
     }
   });
@@ -148,7 +142,7 @@ makeSuite('Gho AToken End-To-End', (testEnv: TestEnv) => {
     ];
     for (const call of calls) {
       await expect(aToken.connect(poolSigner)[call.fn](...call.args)).to.be.revertedWith(
-        OPERATION_NOT_SUPPORTED
+        ProtocolErrors.OPERATION_NOT_SUPPORTED
       );
     }
   });
@@ -170,7 +164,7 @@ makeSuite('Gho AToken End-To-End', (testEnv: TestEnv) => {
 
     await expect(
       aToken.connect(users[5].signer).burn(testAddressOne, testAddressOne, 1000, 1)
-    ).to.be.revertedWith(CALLER_MUST_BE_POOL);
+    ).to.be.revertedWith(ProtocolErrors.CALLER_MUST_BE_POOL);
   });
 
   it('Get VariableDebtToken', async function () {
@@ -290,7 +284,7 @@ makeSuite('Gho AToken End-To-End', (testEnv: TestEnv) => {
     // Underlying cannot be rescued
     await expect(
       aToken.connect(poolAdmin.signer).rescueTokens(gho.address, locker.address, 2)
-    ).to.be.revertedWith(UNDERLYING_CANNOT_BE_RESCUED);
+    ).to.be.revertedWith(ProtocolErrors.UNDERLYING_CANNOT_BE_RESCUED);
     expect(await gho.balanceOf(aToken.address)).to.be.eq(aTokenGhoBalanceBefore.add(amountToLock));
 
     // Lock USDC

--- a/src/test/gho-variable-debt.test.ts
+++ b/src/test/gho-variable-debt.test.ts
@@ -5,6 +5,13 @@ import { impersonateAccountHardhat } from '../helpers/misc-utils';
 import { ghoReserveConfig } from '../helpers/config';
 import { ONE_ADDRESS, ZERO_ADDRESS } from '../helpers/constants';
 import { GhoVariableDebtToken__factory } from '../../types';
+import { ProtocolErrors } from '@aave/core-v3';
+import {
+  INITIALIZED,
+  CALLER_NOT_DISCOUNT_TOKEN,
+  CALLER_NOT_A_TOKEN,
+  ZERO_ADDRESS_NOT_VALID,
+} from './helpers/constants';
 
 makeSuite('Gho VariableDebtToken End-To-End', (testEnv: TestEnv) => {
   let ethers;
@@ -13,15 +20,6 @@ makeSuite('Gho VariableDebtToken End-To-End', (testEnv: TestEnv) => {
 
   const testAddressOne = '0x2acAb3DEa77832C09420663b0E1cB386031bA17B';
   const testAddressTwo = '0x6fC355D4e0EE44b292E50878F49798ff755A5bbC';
-
-  const CALLER_MUST_BE_POOL = '23';
-  const CALLER_NOT_POOL_ADMIN = '1';
-  const OPERATION_NOT_SUPPORTED = '80';
-  const POOL_ADDRESSES_DO_NOT_MATCH = '87';
-  const CALLER_NOT_DISCOUNT_TOKEN = 'CALLER_NOT_DISCOUNT_TOKEN';
-  const CALLER_NOT_A_TOKEN = 'CALLER_NOT_A_TOKEN';
-  const INITIALIZED = 'Contract instance has already been initialized';
-  const ZERO_ADDRESS_NOT_VALID = 'ZERO_ADDRESS_NOT_VALID';
 
   before(async () => {
     ethers = hre.ethers;
@@ -45,7 +43,7 @@ makeSuite('Gho VariableDebtToken End-To-End', (testEnv: TestEnv) => {
 
     await expect(
       variableDebtToken.initialize(ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS, 0, 'test', 'test', [])
-    ).to.be.revertedWith(POOL_ADDRESSES_DO_NOT_MATCH);
+    ).to.be.revertedWith(ProtocolErrors.POOL_ADDRESSES_DO_NOT_MATCH);
   });
 
   it('Update discount distribution - not permissioned (revert expected)', async function () {
@@ -95,7 +93,7 @@ makeSuite('Gho VariableDebtToken End-To-End', (testEnv: TestEnv) => {
     ];
     for (const call of calls) {
       await expect(variableDebtToken.connect(poolSigner)[call.fn](...call.args)).to.be.revertedWith(
-        OPERATION_NOT_SUPPORTED
+        ProtocolErrors.OPERATION_NOT_SUPPORTED
       );
     }
   });
@@ -113,7 +111,7 @@ makeSuite('Gho VariableDebtToken End-To-End', (testEnv: TestEnv) => {
     for (const call of calls) {
       await expect(
         variableDebtToken.connect(nonPoolAdmin.signer)[call.fn](...call.args)
-      ).to.be.revertedWith(CALLER_MUST_BE_POOL);
+      ).to.be.revertedWith(ProtocolErrors.CALLER_MUST_BE_POOL);
     }
   });
 
@@ -132,7 +130,7 @@ makeSuite('Gho VariableDebtToken End-To-End', (testEnv: TestEnv) => {
     for (const call of calls) {
       await expect(
         variableDebtToken.connect(nonPoolAdmin.signer)[call.fn](...call.args)
-      ).to.be.revertedWith(CALLER_NOT_POOL_ADMIN);
+      ).to.be.revertedWith(ProtocolErrors.CALLER_NOT_POOL_ADMIN);
     }
   });
 
@@ -198,7 +196,7 @@ makeSuite('Gho VariableDebtToken End-To-End', (testEnv: TestEnv) => {
     const randomSigner = await impersonateAccountHardhat(testAddressTwo);
     await expect(
       variableDebtToken.connect(randomSigner).updateDiscountRateStrategy(ONE_ADDRESS)
-    ).to.be.revertedWith(CALLER_NOT_POOL_ADMIN);
+    ).to.be.revertedWith(ProtocolErrors.CALLER_NOT_POOL_ADMIN);
   });
 
   it('Get Discount Token - before setting', async function () {
@@ -227,7 +225,7 @@ makeSuite('Gho VariableDebtToken End-To-End', (testEnv: TestEnv) => {
     const randomSigner = await impersonateAccountHardhat(testAddressTwo);
     await expect(
       variableDebtToken.connect(randomSigner).updateDiscountToken(ONE_ADDRESS)
-    ).to.be.revertedWith(CALLER_NOT_POOL_ADMIN);
+    ).to.be.revertedWith(ProtocolErrors.CALLER_NOT_POOL_ADMIN);
   });
 
   it('Set Rebalance Lock Period', async function () {

--- a/src/test/helpers/constants.ts
+++ b/src/test/helpers/constants.ts
@@ -1,0 +1,4 @@
+export const INITIALIZED = 'Contract instance has already been initialized';
+export const ZERO_ADDRESS_NOT_VALID = 'ZERO_ADDRESS_NOT_VALID';
+export const CALLER_NOT_DISCOUNT_TOKEN = 'CALLER_NOT_DISCOUNT_TOKEN';
+export const CALLER_NOT_A_TOKEN = 'CALLER_NOT_A_TOKEN';


### PR DESCRIPTION
- Remove constants error code at tests
- Import Aave protocol errors from latest `@aave/core-v3` package
- Reuse remaining errors outside of Aave protocol at `src/test/helpers/constants.ts`