### PR TITLE
fix: remove unused _transfer

### DIFF
--- a/src/contracts/facilitators/aave/tokens/GhoAToken.sol
+++ b/src/contracts/facilitators/aave/tokens/GhoAToken.sol
@@ -193,18 +193,6 @@ contract GhoAToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base
   }
 
   /**
-   * @notice Transfers the aTokens between two users. Validates the transfer
-   * (ie checks for valid HF after the transfer) if required
-   * @param from The source address
-   * @param to The destination address
-   * @param amount The amount getting transferred
-   * @param validate True if the transfer needs to be validated, false otherwise
-   */
-  function _transfer(address from, address to, uint256 amount, bool validate) internal {
-    revert(Errors.OPERATION_NOT_SUPPORTED);
-  }
-
-  /**
    * @notice Overrides the parent _transfer to force validated transfer() and transferFrom()
    * @param from The source address
    * @param to The destination address


### PR DESCRIPTION
- Removed _transfer function is not required and not used; no codepath depends on it nor is it overriding any interface.

Closes #317 