### PR TITLE
Generic RBAC for GHO token

### DIFF
--- a/certora/applyHarness.patch
+++ b/certora/applyHarness.patch
@@ -46,7 +46,13 @@ diff -ruN ../src/contracts/gho/GhoToken.sol contracts/gho/GhoToken.sol
      require(bytes(_facilitators[facilitator].label).length > 0, 'FACILITATOR_DOES_NOT_EXIST');
  
      uint256 oldCapacity = _facilitators[facilitator].bucketCapacity;
-@@ -130,7 +143,7 @@
+@@ -125,12 +138,12 @@
+   }
+ 
+   /// @inheritdoc IGhoToken
+-  function getFacilitatorBucket(address facilitator) external view returns (uint256, uint256) {
++  function getFacilitatorBucket(address facilitator) public view returns (uint256, uint256) {
+     return (_facilitators[facilitator].bucketCapacity, _facilitators[facilitator].bucketLevel);
    }
  
    /// @inheritdoc IGhoToken

--- a/certora/applyHarness.patch
+++ b/certora/applyHarness.patch
@@ -7,7 +7,7 @@ diff -ruN ../src/.gitignore .gitignore
 diff -ruN ../src/contracts/gho/GhoToken.sol contracts/gho/GhoToken.sol
 --- ../src/contracts/gho/GhoToken.sol	2023-02-26 10:23:14.000000000 +0200
 +++ contracts/gho/GhoToken.sol	2023-02-26 13:26:13.000000000 +0200
-@@ -74,11 +74,16 @@
+@@ -75,11 +75,16 @@
      uint128 bucketCapacity
    ) external onlyRole(FACILITATOR_MANAGER) {
      Facilitator storage facilitator = _facilitators[facilitatorAddress];
@@ -24,7 +24,7 @@ diff -ruN ../src/contracts/gho/GhoToken.sol contracts/gho/GhoToken.sol
  
      _facilitatorsList.add(facilitatorAddress);
  
-@@ -92,6 +97,10 @@
+@@ -93,6 +98,10 @@
    /// @inheritdoc IGhoToken
    function removeFacilitator(address facilitatorAddress) external onlyRole(FACILITATOR_MANAGER) {
      require(
@@ -35,7 +35,7 @@ diff -ruN ../src/contracts/gho/GhoToken.sol contracts/gho/GhoToken.sol
        bytes(_facilitators[facilitatorAddress].label).length > 0,
        'FACILITATOR_DOES_NOT_EXIST'
      );
-@@ -111,6 +120,10 @@
+@@ -112,6 +121,10 @@
      address facilitator,
      uint128 newCapacity
    ) external onlyRole(BUCKET_MANAGER) {
@@ -46,7 +46,7 @@ diff -ruN ../src/contracts/gho/GhoToken.sol contracts/gho/GhoToken.sol
      require(bytes(_facilitators[facilitator].label).length > 0, 'FACILITATOR_DOES_NOT_EXIST');
  
      uint256 oldCapacity = _facilitators[facilitator].bucketCapacity;
-@@ -125,12 +138,12 @@
+@@ -126,12 +139,12 @@
    }
  
    /// @inheritdoc IGhoToken

--- a/certora/applyHarness.patch
+++ b/certora/applyHarness.patch
@@ -7,12 +7,12 @@ diff -ruN ../src/.gitignore .gitignore
 diff -ruN ../src/contracts/gho/GhoToken.sol contracts/gho/GhoToken.sol
 --- ../src/contracts/gho/GhoToken.sol	2023-02-26 10:23:14.000000000 +0200
 +++ contracts/gho/GhoToken.sol	2023-02-26 13:26:13.000000000 +0200
-@@ -71,11 +71,16 @@
+@@ -74,11 +74,16 @@
      uint128 bucketCapacity
-   ) external onlyOwner {
+   ) external onlyRole(FACILITATOR_MANAGER) {
      Facilitator storage facilitator = _facilitators[facilitatorAddress];
 +    require(
-+      !facilitator.isLabelNonempty,    //TODO: remove workaroun when CERT-977 is resolved
++      !facilitator.isLabelNonempty, //TODO: remove workaroun when CERT-977 is resolved
 +      'FACILITATOR_ALREADY_EXISTS'
 +    );
      require(bytes(facilitator.label).length == 0, 'FACILITATOR_ALREADY_EXISTS');
@@ -24,35 +24,29 @@ diff -ruN ../src/contracts/gho/GhoToken.sol contracts/gho/GhoToken.sol
  
      _facilitatorsList.add(facilitatorAddress);
  
-@@ -89,6 +94,10 @@
+@@ -92,6 +97,10 @@
    /// @inheritdoc IGhoToken
-   function removeFacilitator(address facilitatorAddress) external onlyOwner {
+   function removeFacilitator(address facilitatorAddress) external onlyRole(FACILITATOR_MANAGER) {
      require(
-+      _facilitators[facilitatorAddress].isLabelNonempty,    //TODO: remove workaroun when CERT-977 is resolved
++      _facilitators[facilitatorAddress].isLabelNonempty, //TODO: remove workaroun when CERT-977 is resolved
 +      'FACILITATOR_DOES_NOT_EXIST'
 +    );
 +    require(
        bytes(_facilitators[facilitatorAddress].label).length > 0,
        'FACILITATOR_DOES_NOT_EXIST'
      );
-@@ -108,6 +117,10 @@
+@@ -111,6 +120,10 @@
      address facilitator,
      uint128 newCapacity
-   ) external onlyOwner {
+   ) external onlyRole(BUCKET_MANAGER) {
 +    require(
-+      _facilitators[facilitator].isLabelNonempty,    //TODO: remove workaroun when CERT-977 is resolved
++      _facilitators[facilitator].isLabelNonempty, //TODO: remove workaroun when CERT-977 is resolved
 +      'FACILITATOR_DOES_NOT_EXIST'
 +    );
      require(bytes(_facilitators[facilitator].label).length > 0, 'FACILITATOR_DOES_NOT_EXIST');
  
      uint256 oldCapacity = _facilitators[facilitator].bucketCapacity;
-@@ -122,12 +135,12 @@
-   }
- 
-   /// @inheritdoc IGhoToken
--  function getFacilitatorBucket(address facilitator) external view returns (uint256, uint256) {
-+  function getFacilitatorBucket(address facilitator) public view returns (uint256, uint256) {
-     return (_facilitators[facilitator].bucketCapacity, _facilitators[facilitator].bucketLevel);
+@@ -130,7 +143,7 @@
    }
  
    /// @inheritdoc IGhoToken

--- a/certora/harness/GhoTokenHarness.sol
+++ b/certora/harness/GhoTokenHarness.sol
@@ -7,6 +7,8 @@ import {GhoToken} from '../munged/contracts/gho/GhoToken.sol';
 contract GhoTokenHarness is GhoToken {
   using EnumerableSet for EnumerableSet.AddressSet;
 
+  constructor() GhoToken(msg.sender) {}
+
   /**
    * @notice Returns the backet capacity
    * @param facilitator The address of the facilitator

--- a/deploy/00_deploy_gho_token.ts
+++ b/deploy/00_deploy_gho_token.ts
@@ -16,7 +16,7 @@ const func: DeployFunction = async function ({
 
   const ghoResult = await deploy('GhoToken', {
     from: deployer,
-    args: [],
+    args: [deployer],
     log: true,
   });
   console.log(`GHO Address:                   ${ghoResult.address}`);

--- a/src/contracts/gho/GhoToken.sol
+++ b/src/contracts/gho/GhoToken.sol
@@ -21,9 +21,10 @@ contract GhoToken is ERC20, AccessControl, IGhoToken {
 
   /**
    * @dev Constructor
+   * @param admin This is the initial holder of the default admin role
    */
-  constructor() ERC20('Gho Token', 'GHO', 18) {
-    _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
+  constructor(address admin) ERC20('Gho Token', 'GHO', 18) {
+    _setupRole(DEFAULT_ADMIN_ROLE, admin);
   }
 
   /**

--- a/src/contracts/gho/GhoToken.sol
+++ b/src/contracts/gho/GhoToken.sol
@@ -72,11 +72,7 @@ contract GhoToken is ERC20, AccessControl, IGhoToken {
     address facilitatorAddress,
     string calldata facilitatorLabel,
     uint128 bucketCapacity
-  ) external {
-    require(
-      hasRole(DEFAULT_ADMIN_ROLE, msg.sender) || hasRole(FACILITATOR_MANAGER, msg.sender),
-      'CALLER_NOT_ADMIN_OR_FACILITATOR_MANAGER'
-    );
+  ) external onlyRole(FACILITATOR_MANAGER) {
     Facilitator storage facilitator = _facilitators[facilitatorAddress];
     require(bytes(facilitator.label).length == 0, 'FACILITATOR_ALREADY_EXISTS');
     require(bytes(facilitatorLabel).length > 0, 'INVALID_LABEL');
@@ -94,11 +90,7 @@ contract GhoToken is ERC20, AccessControl, IGhoToken {
   }
 
   /// @inheritdoc IGhoToken
-  function removeFacilitator(address facilitatorAddress) external {
-    require(
-      hasRole(DEFAULT_ADMIN_ROLE, msg.sender) || hasRole(FACILITATOR_MANAGER, msg.sender),
-      'CALLER_NOT_ADMIN_OR_FACILITATOR_MANAGER'
-    );
+  function removeFacilitator(address facilitatorAddress) external onlyRole(FACILITATOR_MANAGER) {
     require(
       bytes(_facilitators[facilitatorAddress].label).length > 0,
       'FACILITATOR_DOES_NOT_EXIST'
@@ -115,11 +107,10 @@ contract GhoToken is ERC20, AccessControl, IGhoToken {
   }
 
   /// @inheritdoc IGhoToken
-  function setFacilitatorBucketCapacity(address facilitator, uint128 newCapacity) external {
-    require(
-      hasRole(DEFAULT_ADMIN_ROLE, msg.sender) || hasRole(BUCKET_MANAGER, msg.sender),
-      'CALLER_NOT_ADMIN_OR_BUCKET_MANAGER'
-    );
+  function setFacilitatorBucketCapacity(
+    address facilitator,
+    uint128 newCapacity
+  ) external onlyRole(BUCKET_MANAGER) {
     require(bytes(_facilitators[facilitator].label).length > 0, 'FACILITATOR_DOES_NOT_EXIST');
 
     uint256 oldCapacity = _facilitators[facilitator].bucketCapacity;

--- a/src/test/TestGhoBase.t.sol
+++ b/src/test/TestGhoBase.t.sol
@@ -104,7 +104,7 @@ contract TestGhoBase is Test, Constants, Events {
     CONFIGURATOR = new MockedConfigurator(IPool(POOL));
     GHO_ORACLE = new GhoOracle();
     GHO_MANAGER = new GhoManager();
-    GHO_TOKEN = new GhoToken();
+    GHO_TOKEN = new GhoToken(address(this));
     GHO_TOKEN.grantRole(FACILITATOR_MANAGER, address(this));
     GHO_TOKEN.grantRole(BUCKET_MANAGER, address(this));
     AAVE_TOKEN = new TestnetERC20('AAVE', 'AAVE', 18, FAUCET);

--- a/src/test/TestGhoBase.t.sol
+++ b/src/test/TestGhoBase.t.sol
@@ -105,6 +105,8 @@ contract TestGhoBase is Test, Constants, Events {
     GHO_ORACLE = new GhoOracle();
     GHO_MANAGER = new GhoManager();
     GHO_TOKEN = new GhoToken();
+    GHO_TOKEN.grantRole(FACILITATOR_MANAGER, address(this));
+    GHO_TOKEN.grantRole(BUCKET_MANAGER, address(this));
     AAVE_TOKEN = new TestnetERC20('AAVE', 'AAVE', 18, FAUCET);
     StakedAaveV3 stkAave = new StakedAaveV3(
       IERC20(address(AAVE_TOKEN)),

--- a/src/test/TestGhoToken.t.sol
+++ b/src/test/TestGhoToken.t.sol
@@ -6,7 +6,7 @@ import '@openzeppelin/contracts/utils/Strings.sol';
 
 contract TestGhoToken is TestGhoBase {
   function testConstructor() public {
-    GhoToken ghoToken = new GhoToken();
+    GhoToken ghoToken = new GhoToken(address(this));
     vm.expectEmit(true, true, true, true, address(GHO_TOKEN));
     emit RoleGranted(GHO_TOKEN.DEFAULT_ADMIN_ROLE(), msg.sender, address(this));
     GHO_TOKEN.grantRole(GHO_TOKEN.DEFAULT_ADMIN_ROLE(), msg.sender);

--- a/src/test/TestGhoToken.t.sol
+++ b/src/test/TestGhoToken.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import './TestGhoBase.t.sol';
+import '@openzeppelin/contracts/utils/Strings.sol';
 
 contract TestGhoToken is TestGhoBase {
   function testConstructor() public {
@@ -85,8 +86,14 @@ contract TestGhoToken is TestGhoBase {
   }
 
   function testRevertAddFacilitatorNoRole() public {
+    bytes memory revertMsg = abi.encodePacked(
+      'AccessControl: account ',
+      Strings.toHexString(ALICE),
+      ' is missing role ',
+      Strings.toHexString(uint256(FACILITATOR_MANAGER), 32)
+    );
     vm.prank(ALICE);
-    vm.expectRevert('CALLER_NOT_ADMIN_OR_FACILITATOR_MANAGER');
+    vm.expectRevert(revertMsg);
     GHO_TOKEN.addFacilitator(ALICE, 'Alice', DEFAULT_CAPACITY);
   }
 
@@ -112,8 +119,14 @@ contract TestGhoToken is TestGhoBase {
   }
 
   function testRevertSetNewBucketCapacityNoRole() public {
+    bytes memory revertMsg = abi.encodePacked(
+      'AccessControl: account ',
+      Strings.toHexString(ALICE),
+      ' is missing role ',
+      Strings.toHexString(uint256(BUCKET_MANAGER), 32)
+    );
     vm.prank(ALICE);
-    vm.expectRevert('CALLER_NOT_ADMIN_OR_BUCKET_MANAGER');
+    vm.expectRevert(revertMsg);
     GHO_TOKEN.setFacilitatorBucketCapacity(address(GHO_ATOKEN), 0);
   }
 
@@ -145,8 +158,14 @@ contract TestGhoToken is TestGhoBase {
   }
 
   function testRevertRemoveFacilitatorNoRole() public {
+    bytes memory revertMsg = abi.encodePacked(
+      'AccessControl: account ',
+      Strings.toHexString(ALICE),
+      ' is missing role ',
+      Strings.toHexString(uint256(FACILITATOR_MANAGER), 32)
+    );
     vm.prank(ALICE);
-    vm.expectRevert('CALLER_NOT_ADMIN_OR_FACILITATOR_MANAGER');
+    vm.expectRevert(revertMsg);
     GHO_TOKEN.removeFacilitator(address(GHO_ATOKEN));
   }
 

--- a/src/test/helpers/Constants.sol
+++ b/src/test/helpers/Constants.sol
@@ -6,6 +6,10 @@ contract Constants {
   address constant SHORT_EXECUTOR = 0xEE56e2B3D491590B5b31738cC34d5232F378a8D5;
   address constant STKAAVE_PROXY_ADMIN = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF;
 
+  // admin roles for GhoToken
+  bytes32 public constant FACILITATOR_MANAGER = keccak256('FACILITATOR_MANAGER');
+  bytes32 public constant BUCKET_MANAGER = keccak256('BUCKET_MANAGER');
+
   // defaults used in test environment
   uint256 constant DEFAULT_FLASH_FEE = 0.0009e4; // 0.09%
   uint128 constant DEFAULT_CAPACITY = 100_000_000e18;

--- a/src/test/helpers/Events.sol
+++ b/src/test/helpers/Events.sol
@@ -72,4 +72,7 @@ interface Events {
     address indexed asset,
     uint256 amount
   );
+
+  event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
+  event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
 }

--- a/tasks/roles/00_gho-transfer-ownership.ts
+++ b/tasks/roles/00_gho-transfer-ownership.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import { GhoToken } from './../../../types/src/contracts/gho/GhoToken';
 import { task } from 'hardhat/config';
 
@@ -7,8 +8,8 @@ task('gho-transfer-ownership', 'Transfer Ownership of Gho')
     const DEFAULT_ADMIN_ROLE = hre.ethers.utils.hexZeroPad('0x00', 32);
     const gho = (await hre.ethers.getContract('GhoToken')) as GhoToken;
     const grantAdminRoleTx = await gho.grantRole(DEFAULT_ADMIN_ROLE, newOwner);
-    await grantAdminRoleTx.wait();
-    const signers = await hre.ethers.getSigners();
+    await expect(grantAdminRoleTx).to.emit(gho, 'RoleGranted');
+
     const removeAdminRoleTx = await gho.renounceRole(DEFAULT_ADMIN_ROLE, users[0].address);
 
     console.log(`GHO ownership transferred to:  ${newOwner}`);

--- a/tasks/roles/00_gho-transfer-ownership.ts
+++ b/tasks/roles/00_gho-transfer-ownership.ts
@@ -4,9 +4,12 @@ import { task } from 'hardhat/config';
 task('gho-transfer-ownership', 'Transfer Ownership of Gho')
   .addParam('newOwner')
   .setAction(async ({ newOwner }, hre) => {
+    const DEFAULT_ADMIN_ROLE = hre.ethers.utils.hexZeroPad('0x00', 32);
     const gho = (await hre.ethers.getContract('GhoToken')) as GhoToken;
-    const transferOwnershipTx = await gho.transferOwnership(newOwner);
-    await transferOwnershipTx.wait();
+    const grantAdminRoleTx = await gho.grantRole(DEFAULT_ADMIN_ROLE, newOwner);
+    await grantAdminRoleTx.wait();
+    const signers = await hre.ethers.getSigners();
+    const removeAdminRoleTx = await gho.renounceRole(DEFAULT_ADMIN_ROLE, users[0].address);
 
     console.log(`GHO ownership transferred to:  ${newOwner}`);
   });

--- a/tasks/testnet-setup/00_initialize-gho-reserve.ts
+++ b/tasks/testnet-setup/00_initialize-gho-reserve.ts
@@ -24,6 +24,8 @@ task('initialize-gho-reserve', 'Initialize Gho Reserve').setAction(async (_, hre
   const ghoVariableDebtTokenImplementation = await ethers.getContract('GhoVariableDebtToken');
   const ghoInterestRateStrategy = await ethers.getContract('GhoInterestRateStrategy');
   const ghoToken = await ethers.getContract('GhoToken');
+  ghoToken.grantRole(ghoToken.FACILITATOR_MANAGER(), _deployer.address);
+  ghoToken.grantRole(ghoToken.BUCKET_MANAGER(), _deployer.address);
   const poolConfigurator = await getPoolConfiguratorProxy();
   const treasuryAddress = (await hre.deployments.get(TREASURY_PROXY_ID)).address;
   const incentivesControllerAddress = (await hre.deployments.get(INCENTIVES_PROXY_ID)).address;

--- a/test/flashmint.test.ts
+++ b/test/flashmint.test.ts
@@ -8,6 +8,7 @@ import { ghoEntityConfig } from '../helpers/config';
 import { mintErc20 } from './helpers/user-setup';
 import './helpers/math/wadraymath';
 import { evmRevert, evmSnapshot } from '../helpers/misc-utils';
+import { keccak256, toUtf8Bytes } from 'ethers/lib/utils';
 
 makeSuite('Gho FlashMinter', (testEnv: TestEnv) => {
   let ethers;
@@ -170,12 +171,13 @@ makeSuite('Gho FlashMinter', (testEnv: TestEnv) => {
 
     expect(await aclManager.isFlashBorrower(flashBorrower.address)).to.be.true;
 
-    const DEFAULT_ADMIN_ROLE = ethers.utils.hexZeroPad(ZERO_ADDRESS, 32);
+    const BUCKET_MANAGER_ROLE = ethers.utils.hexZeroPad(
+      keccak256(toUtf8Bytes('BUCKET_MANAGER')),
+      32
+    );
 
-    await expect(gho.connect(ghoOwner.signer).grantRole(DEFAULT_ADMIN_ROLE, flashBorrower.address))
+    await expect(gho.connect(ghoOwner.signer).grantRole(BUCKET_MANAGER_ROLE, flashBorrower.address))
       .to.not.be.reverted;
-    await expect(gho.connect(ghoOwner.signer).renounceRole(DEFAULT_ADMIN_ROLE, ghoOwner.address)).to
-      .not.be.reverted;
 
     expect((await gho.getFacilitatorBucket(flashMinter.address))[0]).to.not.eq(0);
 

--- a/test/flashmint.test.ts
+++ b/test/flashmint.test.ts
@@ -162,7 +162,7 @@ makeSuite('Gho FlashMinter', (testEnv: TestEnv) => {
   it('Flashmint and change capacity mid-execution as approved FlashBorrower', async function () {
     const snapId = await evmSnapshot();
 
-    const { flashMinter, gho, ghoOwner, aclAdmin, aclManager } = testEnv;
+    const { flashMinter, gho, ghoOwner, aclAdmin, aclManager, users } = testEnv;
 
     expect(await aclManager.isFlashBorrower(flashBorrower.address)).to.be.false;
 
@@ -170,8 +170,12 @@ makeSuite('Gho FlashMinter', (testEnv: TestEnv) => {
 
     expect(await aclManager.isFlashBorrower(flashBorrower.address)).to.be.true;
 
-    await expect(gho.connect(ghoOwner.signer).transferOwnership(flashBorrower.address)).to.not.be
-      .reverted;
+    const DEFAULT_ADMIN_ROLE = ethers.utils.hexZeroPad(ZERO_ADDRESS, 32);
+
+    await expect(gho.connect(ghoOwner.signer).grantRole(DEFAULT_ADMIN_ROLE, flashBorrower.address))
+      .to.not.be.reverted;
+    await expect(gho.connect(ghoOwner.signer).renounceRole(DEFAULT_ADMIN_ROLE, ghoOwner.address)).to
+      .not.be.reverted;
 
     expect((await gho.getFacilitatorBucket(flashMinter.address))[0]).to.not.eq(0);
 

--- a/test/gho-token-permit.test.ts
+++ b/test/gho-token-permit.test.ts
@@ -6,6 +6,7 @@ import { HardhatEthersHelpers } from '@nomiclabs/hardhat-ethers/types';
 import { BigNumber } from 'ethers';
 import { HARDHAT_CHAINID, MAX_UINT_AMOUNT, ZERO_ADDRESS } from './../helpers/constants';
 import { buildPermitParams, getSignatureFromTypedData } from './helpers/helpers';
+import { keccak256, toUtf8Bytes } from 'ethers/lib/utils';
 
 describe('GhoToken Unit Test', () => {
   let ethers: typeof import('ethers/lib/ethers') & HardhatEthersHelpers;
@@ -54,6 +55,25 @@ describe('GhoToken Unit Test', () => {
 
   it('Deploys GHO and adds the first facilitator', async function () {
     ghoToken = await ghoTokenFactory.deploy();
+
+    const FACILITATOR_MANAGER_ROLE = ethers.utils.hexZeroPad(
+      keccak256(toUtf8Bytes('FACILITATOR_MANAGER')),
+      32
+    );
+    const BUCKET_MANAGER_ROLE = ethers.utils.hexZeroPad(
+      keccak256(toUtf8Bytes('BUCKET_MANAGER')),
+      32
+    );
+
+    const grantFacilitatorRoleTx = await ghoToken
+      .connect(users[0].signer)
+      .grantRole(FACILITATOR_MANAGER_ROLE, users[0].address);
+    const grantBucketRoleTx = await ghoToken
+      .connect(users[0].signer)
+      .grantRole(BUCKET_MANAGER_ROLE, users[0].address);
+
+    await expect(grantFacilitatorRoleTx).to.emit(ghoToken, 'RoleGranted');
+    await expect(grantBucketRoleTx).to.emit(ghoToken, 'RoleGranted');
 
     const labelHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(facilitator1Label));
 

--- a/test/gho-token-permit.test.ts
+++ b/test/gho-token-permit.test.ts
@@ -54,7 +54,7 @@ describe('GhoToken Unit Test', () => {
   });
 
   it('Deploys GHO and adds the first facilitator', async function () {
-    ghoToken = await ghoTokenFactory.deploy();
+    ghoToken = await ghoTokenFactory.deploy(users[0].address);
 
     const FACILITATOR_MANAGER_ROLE = ethers.utils.hexZeroPad(
       keccak256(toUtf8Bytes('FACILITATOR_MANAGER')),

--- a/test/gho-token-unit.test.ts
+++ b/test/gho-token-unit.test.ts
@@ -129,10 +129,11 @@ describe('GhoToken Unit Test', () => {
 
     expect(deploymentReceipt.logs.length).to.be.equal(1);
     const ownershipEvent = ghoToken.interface.parseLog(deploymentReceipt.logs[0]);
+    const DEFAULT_ADMIN_ROLE = ethers.utils.hexZeroPad(ZERO_ADDRESS, 32);
 
-    expect(ownershipEvent.name).to.equal('OwnershipTransferred');
-    expect(ownershipEvent.args.previousOwner).to.equal(ZERO_ADDRESS);
-    expect(ownershipEvent.args.newOwner).to.equal(users[0].address);
+    expect(ownershipEvent.name).to.equal('RoleGranted');
+    expect(ownershipEvent.args.role).to.equal(DEFAULT_ADMIN_ROLE);
+    expect(ownershipEvent.args.account).to.equal(users[0].address);
 
     const labelHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(facilitator1Label));
     const addFacilitatorTx = await ghoToken
@@ -285,7 +286,7 @@ describe('GhoToken Unit Test', () => {
       ghoToken
         .connect(facilitator1.signer)
         .setFacilitatorBucketCapacity(facilitator1.address, facilitator1UpdatedCap)
-    ).to.be.revertedWith('Ownable: caller is not the owner');
+    ).to.be.revertedWith('CALLER_NOT_ADMIN_OR_BUCKET_MANAGER');
   });
 
   it('Update capacity of a non-existent facilitator - (revert expected)', async function () {
@@ -335,7 +336,7 @@ describe('GhoToken Unit Test', () => {
           facilitator4Config.label,
           facilitator4Config.bucketCapacity
         )
-    ).to.be.revertedWith('Ownable: caller is not the owner');
+    ).to.be.revertedWith('CALLER_NOT_ADMIN_OR_FACILITATOR_MANAGER');
   });
 
   it('Add facilitator already added - (revert expected)', async function () {
@@ -394,7 +395,7 @@ describe('GhoToken Unit Test', () => {
   it('Remove facilitator from non-owner - (revert expected)', async function () {
     await expect(
       ghoToken.connect(facilitator1.signer).removeFacilitator(facilitator3.address)
-    ).to.be.revertedWith('Ownable: caller is not the owner');
+    ).to.be.revertedWith('CALLER_NOT_ADMIN_OR_FACILITATOR_MANAGER');
   });
 
   it('Remove facilitator3', async function () {

--- a/test/gho-token-unit.test.ts
+++ b/test/gho-token-unit.test.ts
@@ -120,7 +120,7 @@ describe('GhoToken Unit Test', () => {
   });
 
   it('Deploy GhoToken without facilitators', async function () {
-    const tempGhoToken = await ghoTokenFactory.deploy();
+    const tempGhoToken = await ghoTokenFactory.deploy(users[0].address);
 
     const { TOKEN_DECIMALS, TOKEN_NAME, TOKEN_SYMBOL } = ghoTokenConfig;
 
@@ -132,7 +132,7 @@ describe('GhoToken Unit Test', () => {
   });
 
   it('Deploys GHO and adds the first facilitator', async function () {
-    ghoToken = await ghoTokenFactory.deploy();
+    ghoToken = await ghoTokenFactory.deploy(users[0].address);
 
     const deploymentReceipt = await ethers.provider.getTransactionReceipt(
       ghoToken.deployTransaction.hash


### PR DESCRIPTION
Will close #331 .

Adds 2 roles via OZ AccessControl (in addition to the DEFAULT_ADMIN_ROLE that replaces Owner), FACILITATOR_MANAGER that can add/remove facilitators and a BUCKET_MANAGER that can set bucket capacities.

POSSIBLE TODO: Expand scope of RBAC to allow for both role assignments and per-facilitator assignment of a role-holder to a facilitator; optional at this stage since it can be done via external helpers.