### PR TITLE
feat: Add upgradeable GHO Token

### DIFF
--- a/.github/workflows/certora-gho.yml
+++ b/.github/workflows/certora-gho.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         rule:
           - verifyUpgradeableGhoToken.conf
-          - verifyGhoToken.conf 
+          - verifyGhoToken.conf
           - verifyGhoAToken.conf --rule noMint noBurn noTransfer transferUnderlyingToCantExceedCapacity totalSupplyAlwaysZero userBalanceAlwaysZero level_does_not_decrease_after_transferUnderlyingTo_followed_by_handleRepayment
           - verifyGhoDiscountRateStrategy.conf --rule equivalenceOfWadMulCVLAndWadMulSol maxDiscountForHighDiscountTokenBalance zeroDiscountForSmallDiscountTokenBalance partialDiscountForIntermediateTokenBalance limitOnDiscountRate
           - verifyFlashMinter.conf --rule balanceOfFlashMinterGrows integrityOfTreasurySet integrityOfFeeSet availableLiquidityDoesntChange integrityOfDistributeFeesToTreasury feeSimulationEqualsActualFee

--- a/.github/workflows/certora-gho.yml
+++ b/.github/workflows/certora-gho.yml
@@ -52,7 +52,8 @@ jobs:
       max-parallel: 16
       matrix:
         rule:
-          - verifyGhoToken.conf --rule length_leq_max_uint160 inv_balanceOf_leq_totalSupply total_supply_eq_sumAllLevel sumAllBalance_eq_totalSupply sumAllLevel_eq_sumAllBalance inv_valid_capacity inv_valid_level address_in_set_values_iff_in_set_indexes addr_in_set_iff_in_map addr_in_set_list_iff_in_map level_leq_capacity mint_after_burn burn_after_mint level_unchanged_after_mint_followed_by_burn level_after_mint level_after_burn facilitator_in_list_after_setFacilitatorBucketCapacity getFacilitatorBucketCapacity_after_setFacilitatorBucketCapacity facilitator_in_list_after_addFacilitator facilitator_in_list_after_mint_and_burn address_not_in_list_after_removeFacilitator balance_after_mint balance_after_burn mintLimitedByFacilitatorRemainingCapacity burnLimitedByFacilitatorLevel ARRAY_IS_INVERSE_OF_MAP_Invariant addressSetInvariant address_not_in_list_after_removeFacilitator_CASE_SPLIT_zero_address
+          - verifyUpgradeableGhoToken.conf
+          - verifyGhoToken.conf 
           - verifyGhoAToken.conf --rule noMint noBurn noTransfer transferUnderlyingToCantExceedCapacity totalSupplyAlwaysZero userBalanceAlwaysZero level_does_not_decrease_after_transferUnderlyingTo_followed_by_handleRepayment
           - verifyGhoDiscountRateStrategy.conf --rule equivalenceOfWadMulCVLAndWadMulSol maxDiscountForHighDiscountTokenBalance zeroDiscountForSmallDiscountTokenBalance partialDiscountForIntermediateTokenBalance limitOnDiscountRate
           - verifyFlashMinter.conf --rule balanceOfFlashMinterGrows integrityOfTreasurySet integrityOfFeeSet availableLiquidityDoesntChange integrityOfDistributeFeesToTreasury feeSimulationEqualsActualFee

--- a/.github/workflows/certora-gsm.yml
+++ b/.github/workflows/certora-gsm.yml
@@ -58,7 +58,8 @@ jobs:
           - non-4626/Alex-gho-gsm.conf
           - non-4626/balances-buy.conf
           - non-4626/balances-sell.conf
-          - non-4626/Dominik-gho-assetToGhoInvertibility.conf --rule basicProperty_getAssetAmountForBuyAsset sellAssetInverse_all buyAssetInverse_all basicProperty_getGhoAmountForSellAsset basicProperty_getAssetAmountForSellAsset basicProperty_getGhoAmountForBuyAsset basicProperty2_getAssetAmountForBuyAsset
+          - non-4626/Dominik-gho-assetToGhoInvertibility.conf --rule basicProperty_getAssetAmountForBuyAsset sellAssetInverse_all buyAssetInverse_all basicProperty_getGhoAmountForSellAsset basicProperty_getAssetAmountForSellAsset basicProperty_getGhoAmountForBuyAsset
+          - non-4626/Dominik-gho-assetToGhoInvertibility.conf --rule basicProperty2_getAssetAmountForBuyAsset
           - non-4626/Dominik-gho-fixedPriceStrategy.conf
           - non-4626/fees-buy.conf
           - non-4626/fees-sell.conf

--- a/certora/GSM/conf/non-4626/otakar-OracleSwapFreezer.conf
+++ b/certora/GSM/conf/non-4626/otakar-OracleSwapFreezer.conf
@@ -22,8 +22,6 @@
     "prover_args": [
         "-copyLoopUnroll 6",
         "-depth 20",
-//        "-newSplitParallel true",
-//        "-smt_hashingScheme plainInjectivity",
     ],
     "verify":
         "OracleSwapFreezerHarness:certora/GSM/specs/gsm/otakar-OracleSwapFreezer.spec",

--- a/certora/GSM/conf/non-4626/otakar-finishedRules.conf
+++ b/certora/GSM/conf/non-4626/otakar-finishedRules.conf
@@ -32,8 +32,6 @@
     "prover_args": [
         "-copyLoopUnroll 6",
         "-depth 20",
-//        "-newSplitParallel true",
-//        "-smt_hashingScheme plainInjectivity",
     ],
     "verify":
         "GsmHarness:certora/GSM/specs/gsm/otakar-gho-gsm-finishedRules.spec",

--- a/certora/GSM/specs/gsm/Dominik-AssetToGhoInvertibility.spec
+++ b/certora/GSM/specs/gsm/Dominik-AssetToGhoInvertibility.spec
@@ -18,7 +18,7 @@ function mulDivSummary(uint256 x, uint256 y, uint256 denominator) returns uint25
 function mulDivSummaryWithRounding(uint256 x, uint256 y, uint256 denominator, Math.Rounding rounding) returns uint256
 {
     require denominator > 0;
-    if rounding == Math.Rounding.Up
+    if (rounding == Math.Rounding.Up)
     {
         return require_uint256((x * y + denominator - 1) / denominator);
     }

--- a/certora/GSM/specs/gsm/Dominik-FixedPriceStrategy.spec
+++ b/certora/GSM/specs/gsm/Dominik-FixedPriceStrategy.spec
@@ -19,7 +19,7 @@ function mulDivSummary(uint256 x, uint256 y, uint256 denominator) returns uint25
 function mulDivSummaryWithRounding(uint256 x, uint256 y, uint256 denominator, Math.Rounding rounding) returns uint256
 {
     require denominator > 0;
-    if rounding == Math.Rounding.Up
+    if (rounding == Math.Rounding.Up)
     {
         return require_uint256((x * y + denominator - 1) / denominator);
     }

--- a/certora/gho/applyHarness.patch
+++ b/certora/gho/applyHarness.patch
@@ -1,13 +1,7 @@
-diff -ruN ../src/.gitignore .gitignore
---- ../src/.gitignore	1970-01-01 02:00:00.000000000 +0200
-+++ .gitignore	2023-02-26 11:58:05.000000000 +0200
-@@ -0,0 +1,2 @@
-+*
-+!.gitignore
-diff -ruN ../src/contracts/gho/GhoToken.sol contracts/gho/GhoToken.sol
---- ../src/contracts/gho/GhoToken.sol	2023-02-26 10:23:14.000000000 +0200
-+++ contracts/gho/GhoToken.sol	2023-02-26 13:26:13.000000000 +0200
-@@ -74,11 +74,16 @@
+diff -ruN ../../src/contracts/gho/GhoToken.sol contracts/gho/GhoToken.sol
+--- ../../src/contracts/gho/GhoToken.sol	2024-05-21 10:57:52.000000000 +0300
++++ contracts/gho/GhoToken.sol	2024-05-27 12:55:24.588859419 +0300
+@@ -66,11 +66,16 @@
      uint128 bucketCapacity
    ) external onlyRole(FACILITATOR_MANAGER_ROLE) {
      Facilitator storage facilitator = _facilitators[facilitatorAddress];
@@ -24,9 +18,9 @@ diff -ruN ../src/contracts/gho/GhoToken.sol contracts/gho/GhoToken.sol
  
      _facilitatorsList.add(facilitatorAddress);
  
-@@ -92,6 +97,10 @@
-   /// @inheritdoc IGhoToken
-   function removeFacilitator(address facilitatorAddress) external onlyRole(FACILITATOR_MANAGER_ROLE) {
+@@ -86,6 +91,10 @@
+     address facilitatorAddress
+   ) external onlyRole(FACILITATOR_MANAGER_ROLE) {
      require(
 +      _facilitators[facilitatorAddress].isLabelNonempty, //TODO: remove workaroun when CERT-977 is resolved
 +      'FACILITATOR_DOES_NOT_EXIST'
@@ -35,7 +29,7 @@ diff -ruN ../src/contracts/gho/GhoToken.sol contracts/gho/GhoToken.sol
        bytes(_facilitators[facilitatorAddress].label).length > 0,
        'FACILITATOR_DOES_NOT_EXIST'
      );
-@@ -111,6 +120,10 @@
+@@ -105,6 +114,10 @@
      address facilitator,
      uint128 newCapacity
    ) external onlyRole(BUCKET_MANAGER_ROLE) {
@@ -46,7 +40,7 @@ diff -ruN ../src/contracts/gho/GhoToken.sol contracts/gho/GhoToken.sol
      require(bytes(_facilitators[facilitator].label).length > 0, 'FACILITATOR_DOES_NOT_EXIST');
  
      uint256 oldCapacity = _facilitators[facilitator].bucketCapacity;
-@@ -125,12 +138,12 @@
+@@ -119,12 +132,12 @@
    }
  
    /// @inheritdoc IGhoToken
@@ -61,10 +55,10 @@ diff -ruN ../src/contracts/gho/GhoToken.sol contracts/gho/GhoToken.sol
      return _facilitatorsList.values();
    }
  }
-diff -ruN ../src/contracts/gho/interfaces/IGhoToken.sol contracts/gho/interfaces/IGhoToken.sol
---- ../src/contracts/gho/interfaces/IGhoToken.sol	2023-02-26 10:23:14.000000000 +0200
-+++ contracts/gho/interfaces/IGhoToken.sol	2023-02-26 11:58:05.000000000 +0200
-@@ -14,6 +14,7 @@
+diff -ruN ../../src/contracts/gho/interfaces/IGhoToken.sol contracts/gho/interfaces/IGhoToken.sol
+--- ../../src/contracts/gho/interfaces/IGhoToken.sol	2024-05-21 10:57:52.000000000 +0300
++++ contracts/gho/interfaces/IGhoToken.sol	2024-05-27 12:55:24.588859419 +0300
+@@ -13,6 +13,7 @@
      uint128 bucketCapacity;
      uint128 bucketLevel;
      string label;
@@ -72,3 +66,66 @@ diff -ruN ../src/contracts/gho/interfaces/IGhoToken.sol contracts/gho/interfaces
    }
  
    /**
+diff -ruN ../../src/contracts/gho/UpgradeableGhoToken.sol contracts/gho/UpgradeableGhoToken.sol
+--- ../../src/contracts/gho/UpgradeableGhoToken.sol	2024-05-21 11:57:23.000000000 +0300
++++ contracts/gho/UpgradeableGhoToken.sol	2024-05-27 15:04:16.458997293 +0300
+@@ -76,11 +76,16 @@
+     uint128 bucketCapacity
+   ) external onlyRole(FACILITATOR_MANAGER_ROLE) {
+     Facilitator storage facilitator = _facilitators[facilitatorAddress];
++    require(
++      !facilitator.isLabelNonempty, //TODO: remove workaroun when CERT-977 is resolved
++      'FACILITATOR_ALREADY_EXISTS'
++    );
+     require(bytes(facilitator.label).length == 0, 'FACILITATOR_ALREADY_EXISTS');
+     require(bytes(facilitatorLabel).length > 0, 'INVALID_LABEL');
+ 
+     facilitator.label = facilitatorLabel;
+     facilitator.bucketCapacity = bucketCapacity;
++    facilitator.isLabelNonempty = true;
+ 
+     _facilitatorsList.add(facilitatorAddress);
+ 
+@@ -96,6 +101,10 @@
+     address facilitatorAddress
+   ) external onlyRole(FACILITATOR_MANAGER_ROLE) {
+     require(
++      _facilitators[facilitatorAddress].isLabelNonempty, //TODO: remove workaroun when CERT-977 is resolved
++      'FACILITATOR_DOES_NOT_EXIST'
++    );
++    require(
+       bytes(_facilitators[facilitatorAddress].label).length > 0,
+       'FACILITATOR_DOES_NOT_EXIST'
+     );
+@@ -115,6 +124,10 @@
+     address facilitator,
+     uint128 newCapacity
+   ) external onlyRole(BUCKET_MANAGER_ROLE) {
++    require(
++      _facilitators[facilitator].isLabelNonempty, //TODO: remove workaroun when CERT-977 is resolved
++      'FACILITATOR_DOES_NOT_EXIST'
++    );
+     require(bytes(_facilitators[facilitator].label).length > 0, 'FACILITATOR_DOES_NOT_EXIST');
+ 
+     uint256 oldCapacity = _facilitators[facilitator].bucketCapacity;
+@@ -129,12 +142,12 @@
+   }
+ 
+   /// @inheritdoc IGhoToken
+-  function getFacilitatorBucket(address facilitator) external view returns (uint256, uint256) {
++  function getFacilitatorBucket(address facilitator) public view returns (uint256, uint256) {
+     return (_facilitators[facilitator].bucketCapacity, _facilitators[facilitator].bucketLevel);
+   }
+ 
+   /// @inheritdoc IGhoToken
+-  function getFacilitatorsList() external view returns (address[] memory) {
++  function getFacilitatorsList() public view returns (address[] memory) {
+     return _facilitatorsList.values();
+   }
+ 
+diff -ruN ../../src/.gitignore .gitignore
+--- ../../src/.gitignore	1970-01-01 02:00:00.000000000 +0200
++++ .gitignore	2024-05-27 12:55:24.588859419 +0300
+@@ -0,0 +1,2 @@
++*
++!.gitignore

--- a/certora/gho/conf/verifyUpgradeableGhoToken.conf
+++ b/certora/gho/conf/verifyUpgradeableGhoToken.conf
@@ -3,10 +3,8 @@
         "certora/gho/harness/UpgradeableGhoTokenHarness.sol:UpgradeableGhoTokenHarness",
     ],
     "packages": [
-        "@aave/core-v3/=lib/aave-v3-core",
-        "@aave/periphery-v3/=lib/aave-v3-periphery",
-        "@aave/=lib/aave-token",
         "@openzeppelin/=lib/openzeppelin-contracts",
+        "solidity-utils/=lib/solidity-utils/src/",
     ],
     "loop_iter": "3",
     "msg": "GhoToken, all rules.",

--- a/certora/gho/conf/verifyUpgradeableGhoToken.conf
+++ b/certora/gho/conf/verifyUpgradeableGhoToken.conf
@@ -1,6 +1,6 @@
 {
     "files": [
-        "certora/gho/harness/GhoTokenHarness.sol:GhoTokenHarness",
+        "certora/gho/harness/UpgradeableGhoTokenHarness.sol:UpgradeableGhoTokenHarness",
     ],
     "packages": [
         "@aave/core-v3/=lib/aave-v3-core",
@@ -13,5 +13,5 @@
     "optimistic_loop": true,
     "process": "emv",
     "solc": "solc8.10",
-    "verify": "GhoTokenHarness:certora/gho/specs/ghoToken.spec"
+    "verify": "UpgradeableGhoTokenHarness:certora/gho/specs/ghoToken.spec"
 }

--- a/certora/gho/harness/DummyPool.sol
+++ b/certora/gho/harness/DummyPool.sol
@@ -7,6 +7,6 @@ contract DummyPool {
     address asset,
     uint256 blockTs
   ) internal view returns (uint256) {
-    return 0; // will be replaced by a sammury in the spec file
+    return 0; // will be replaced by a summary in the spec file
   }
 }

--- a/certora/gho/harness/UpgradeableGhoTokenHarness.sol
+++ b/certora/gho/harness/UpgradeableGhoTokenHarness.sol
@@ -1,0 +1,84 @@
+pragma solidity ^0.8.0;
+
+import {IGhoToken} from '../munged/contracts/gho/interfaces/IGhoToken.sol';
+import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+import {UpgradeableGhoToken} from '../munged/contracts/gho/UpgradeableGhoToken.sol';
+
+contract UpgradeableGhoTokenHarness is UpgradeableGhoToken {
+  using EnumerableSet for EnumerableSet.AddressSet;
+
+  constructor() UpgradeableGhoToken() {}
+
+  /**
+   * @notice Returns the bucket capacity
+   * @param facilitator The address of the facilitator
+   * @return The facilitator bucket capacity
+   */
+  function getFacilitatorBucketCapacity(address facilitator) public view returns (uint256) {
+    (uint256 bucketCapacity, ) = getFacilitatorBucket(facilitator);
+    return bucketCapacity;
+  }
+
+  /**
+   * @notice Returns the bucket level
+   * @param facilitator The address of the facilitator
+   * @return The facilitator bucket level
+   */
+  function getFacilitatorBucketLevel(address facilitator) public view returns (uint256) {
+    (, uint256 bucketLevel) = getFacilitatorBucket(facilitator);
+    return bucketLevel;
+  }
+
+  /**
+   * @notice Returns the length of the facilitator list
+   * @return The length of the facilitator list
+   */
+  function getFacilitatorsListLen() external view returns (uint256) {
+    address[] memory flist = getFacilitatorsList();
+    return flist.length;
+  }
+
+  /**
+   * @notice Indicator of GhoToken mapping
+   * @param addr An address of a facilitator
+   * @return True of facilitator is in GhoToken mapping
+   */
+  function is_in_facilitator_mapping(address addr) external view returns (bool) {
+    Facilitator memory facilitator = _facilitators[addr];
+    return facilitator.isLabelNonempty; //TODO: remove workaround when CERT-977 is resolved
+    //  return (bytes(facilitator.label).length > 0);
+  }
+
+  /**
+   * @notice Indicator of AddressSet mapping
+   * @param addr An address of a facilitator
+   * @return True of facilitator is in AddressSet mapping
+   */
+  function is_in_facilitator_set_map(address addr) external view returns (bool) {
+    return _facilitatorsList.contains(addr);
+  }
+
+  /**
+   * @notice Indicator of AddressSet list
+   * @param addr An address of a facilitator
+   * @return True of facilitator is in AddressSet array
+   */
+  function is_in_facilitator_set_array(address addr) external view returns (bool) {
+    address[] memory flist = getFacilitatorsList();
+    for (uint256 i = 0; i < flist.length; ++i) {
+      if (address(flist[i]) == addr) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * @notice Converts address to bytes32
+   * @param value Some address
+   * @return b the value as bytes32
+   */
+  function to_bytes32(address value) external pure returns (bytes32 b) {
+    b = bytes32(uint256(uint160(value)));
+  }
+}

--- a/certora/gho/specs/ghoToken.spec
+++ b/certora/gho/specs/ghoToken.spec
@@ -1,6 +1,5 @@
 import "set.spec";
 
-using GhoToken as GHOTOKEN;
 methods{
 	function mint(address,uint256) external;
 	function burn(uint256) external;
@@ -15,7 +14,6 @@ methods{
 	function is_in_facilitator_mapping(address) external returns bool envfree;
 	function is_in_facilitator_set_map(address) external returns bool envfree;
 	function is_in_facilitator_set_array(address) external returns bool envfree;
-	//function to_bytes32(address) external returns (bytes32) envfree;
 }
 
 ghost sumAllBalance() returns mathint {

--- a/src/contracts/facilitators/aave/interestStrategy/FixedRateStrategyFactory.sol
+++ b/src/contracts/facilitators/aave/interestStrategy/FixedRateStrategyFactory.sol
@@ -30,7 +30,7 @@ contract FixedRateStrategyFactory is VersionedInitializable, IFixedRateStrategyF
 
   /**
    * @notice FixedRateStrategyFactory initializer
-   * @dev asumes that the addresses provided are fixed rate deployed strategies.
+   * @dev assumes that the addresses provided are fixed rate deployed strategies.
    * @param fixedRateStrategiesList List of fixed rate strategies
    */
   function initialize(address[] memory fixedRateStrategiesList) external initializer {

--- a/src/contracts/gho/UpgradeableERC20.sol
+++ b/src/contracts/gho/UpgradeableERC20.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT-only
+pragma solidity ^0.8.0;
+
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+
+/**
+ * @title UpgradeableERC20
+ * @author Aave Labs
+ * @notice Upgradeable version of Solmate ERC20
+ * @dev Contract adaptations:
+ * - Removal of domain separator optimization
+ * - Move of name and symbol definition to initialization stage
+ */
+abstract contract UpgradeableERC20 is IERC20 {
+  /*///////////////////////////////////////////////////////////////
+                             METADATA STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+  string public name;
+
+  string public symbol;
+
+  uint8 public immutable decimals;
+
+  /*///////////////////////////////////////////////////////////////
+                              ERC20 STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+  uint256 public totalSupply;
+
+  mapping(address => uint256) public balanceOf;
+
+  mapping(address => mapping(address => uint256)) public allowance;
+
+  /*///////////////////////////////////////////////////////////////
+                             EIP-2612 STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+  bytes32 public constant PERMIT_TYPEHASH =
+    keccak256('Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)');
+
+  mapping(address => uint256) public nonces;
+
+  /*///////////////////////////////////////////////////////////////
+                               CONSTRUCTOR
+    //////////////////////////////////////////////////////////////*/
+
+  constructor(uint8 _decimals) {
+    decimals = _decimals;
+  }
+
+  /*///////////////////////////////////////////////////////////////
+                               INITIALIZER
+    //////////////////////////////////////////////////////////////*/
+
+  function _ERC20_init(string memory _name, string memory _symbol) internal {
+    name = _name;
+    symbol = _symbol;
+  }
+
+  /*///////////////////////////////////////////////////////////////
+                              ERC20 LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+  function approve(address spender, uint256 amount) public virtual returns (bool) {
+    allowance[msg.sender][spender] = amount;
+
+    emit Approval(msg.sender, spender, amount);
+
+    return true;
+  }
+
+  function transfer(address to, uint256 amount) public virtual returns (bool) {
+    balanceOf[msg.sender] -= amount;
+
+    // Cannot overflow because the sum of all user
+    // balances can't exceed the max uint256 value.
+    unchecked {
+      balanceOf[to] += amount;
+    }
+
+    emit Transfer(msg.sender, to, amount);
+
+    return true;
+  }
+
+  function transferFrom(address from, address to, uint256 amount) public virtual returns (bool) {
+    uint256 allowed = allowance[from][msg.sender]; // Saves gas for limited approvals.
+
+    if (allowed != type(uint256).max) allowance[from][msg.sender] = allowed - amount;
+
+    balanceOf[from] -= amount;
+
+    // Cannot overflow because the sum of all user
+    // balances can't exceed the max uint256 value.
+    unchecked {
+      balanceOf[to] += amount;
+    }
+
+    emit Transfer(from, to, amount);
+
+    return true;
+  }
+
+  /*///////////////////////////////////////////////////////////////
+                              EIP-2612 LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+  function permit(
+    address owner,
+    address spender,
+    uint256 value,
+    uint256 deadline,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) public virtual {
+    require(deadline >= block.timestamp, 'PERMIT_DEADLINE_EXPIRED');
+
+    // Unchecked because the only math done is incrementing
+    // the owner's nonce which cannot realistically overflow.
+    unchecked {
+      bytes32 digest = keccak256(
+        abi.encodePacked(
+          '\x19\x01',
+          DOMAIN_SEPARATOR(),
+          keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonces[owner]++, deadline))
+        )
+      );
+
+      address recoveredAddress = ecrecover(digest, v, r, s);
+
+      require(recoveredAddress != address(0) && recoveredAddress == owner, 'INVALID_SIGNER');
+
+      allowance[recoveredAddress][spender] = value;
+    }
+
+    emit Approval(owner, spender, value);
+  }
+
+  function DOMAIN_SEPARATOR() public view virtual returns (bytes32) {
+    return computeDomainSeparator();
+  }
+
+  function computeDomainSeparator() internal view virtual returns (bytes32) {
+    return
+      keccak256(
+        abi.encode(
+          keccak256(
+            'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'
+          ),
+          keccak256(bytes(name)),
+          keccak256('1'),
+          block.chainid,
+          address(this)
+        )
+      );
+  }
+
+  /*///////////////////////////////////////////////////////////////
+                       INTERNAL MINT/BURN LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+  function _mint(address to, uint256 amount) internal virtual {
+    totalSupply += amount;
+
+    // Cannot overflow because the sum of all user
+    // balances can't exceed the max uint256 value.
+    unchecked {
+      balanceOf[to] += amount;
+    }
+
+    emit Transfer(address(0), to, amount);
+  }
+
+  function _burn(address from, uint256 amount) internal virtual {
+    balanceOf[from] -= amount;
+
+    // Cannot underflow because a user's balance
+    // will never be larger than the total supply.
+    unchecked {
+      totalSupply -= amount;
+    }
+
+    emit Transfer(from, address(0), amount);
+  }
+}

--- a/src/contracts/gho/UpgradeableGhoToken.sol
+++ b/src/contracts/gho/UpgradeableGhoToken.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {EnumerableSet} from '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
 import {AccessControl} from '@openzeppelin/contracts/access/AccessControl.sol';
-import {VersionedInitializable} from '@aave/core-v3/contracts/protocol/libraries/aave-upgradeability/VersionedInitializable.sol';
+import {Initializable} from 'solidity-utils/contracts/transparent-proxy/Initializable.sol';
 import {UpgradeableERC20} from './UpgradeableERC20.sol';
 import {IGhoToken} from './interfaces/IGhoToken.sol';
 
@@ -11,7 +11,7 @@ import {IGhoToken} from './interfaces/IGhoToken.sol';
  * @title Upgradeable GHO Token
  * @author Aave Labs
  */
-contract UpgradeableGhoToken is VersionedInitializable, UpgradeableERC20, AccessControl, IGhoToken {
+contract UpgradeableGhoToken is Initializable, UpgradeableERC20, AccessControl, IGhoToken {
   using EnumerableSet for EnumerableSet.AddressSet;
 
   mapping(address => Facilitator) internal _facilitators;
@@ -136,18 +136,5 @@ contract UpgradeableGhoToken is VersionedInitializable, UpgradeableERC20, Access
   /// @inheritdoc IGhoToken
   function getFacilitatorsList() external view returns (address[] memory) {
     return _facilitatorsList.values();
-  }
-
-  /**
-   * @notice Returns the revision number
-   * @return The revision number
-   */
-  function REVISION() public pure virtual returns (uint256) {
-    return 1;
-  }
-
-  /// @inheritdoc VersionedInitializable
-  function getRevision() internal pure virtual override returns (uint256) {
-    return REVISION();
   }
 }

--- a/src/contracts/gho/UpgradeableGhoToken.sol
+++ b/src/contracts/gho/UpgradeableGhoToken.sol
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {EnumerableSet} from '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+import {AccessControl} from '@openzeppelin/contracts/access/AccessControl.sol';
+import {VersionedInitializable} from '@aave/core-v3/contracts/protocol/libraries/aave-upgradeability/VersionedInitializable.sol';
+import {UpgradeableERC20} from './UpgradeableERC20.sol';
+import {IGhoToken} from './interfaces/IGhoToken.sol';
+
+/**
+ * @title Upgradeable GHO Token
+ * @author Aave Labs
+ */
+contract UpgradeableGhoToken is VersionedInitializable, UpgradeableERC20, AccessControl, IGhoToken {
+  using EnumerableSet for EnumerableSet.AddressSet;
+
+  mapping(address => Facilitator) internal _facilitators;
+  EnumerableSet.AddressSet internal _facilitatorsList;
+
+  /// @inheritdoc IGhoToken
+  bytes32 public constant FACILITATOR_MANAGER_ROLE = keccak256('FACILITATOR_MANAGER_ROLE');
+
+  /// @inheritdoc IGhoToken
+  bytes32 public constant BUCKET_MANAGER_ROLE = keccak256('BUCKET_MANAGER_ROLE');
+
+  /**
+   * @dev Constructor
+   */
+  constructor() UpgradeableERC20(18) {
+    // Intentionally left bank
+  }
+
+  /**
+   * @dev Initializer
+   * @param admin This is the initial holder of the default admin role
+   */
+  function initialize(address admin) public virtual initializer {
+    _ERC20_init('Gho Token', 'GHO');
+
+    _setupRole(DEFAULT_ADMIN_ROLE, admin);
+  }
+
+  /// @inheritdoc IGhoToken
+  function mint(address account, uint256 amount) external {
+    require(amount > 0, 'INVALID_MINT_AMOUNT');
+    Facilitator storage f = _facilitators[msg.sender];
+
+    uint256 currentBucketLevel = f.bucketLevel;
+    uint256 newBucketLevel = currentBucketLevel + amount;
+    require(f.bucketCapacity >= newBucketLevel, 'FACILITATOR_BUCKET_CAPACITY_EXCEEDED');
+    f.bucketLevel = uint128(newBucketLevel);
+
+    _mint(account, amount);
+
+    emit FacilitatorBucketLevelUpdated(msg.sender, currentBucketLevel, newBucketLevel);
+  }
+
+  /// @inheritdoc IGhoToken
+  function burn(uint256 amount) external {
+    require(amount > 0, 'INVALID_BURN_AMOUNT');
+
+    Facilitator storage f = _facilitators[msg.sender];
+    uint256 currentBucketLevel = f.bucketLevel;
+    uint256 newBucketLevel = currentBucketLevel - amount;
+    f.bucketLevel = uint128(newBucketLevel);
+
+    _burn(msg.sender, amount);
+
+    emit FacilitatorBucketLevelUpdated(msg.sender, currentBucketLevel, newBucketLevel);
+  }
+
+  /// @inheritdoc IGhoToken
+  function addFacilitator(
+    address facilitatorAddress,
+    string calldata facilitatorLabel,
+    uint128 bucketCapacity
+  ) external onlyRole(FACILITATOR_MANAGER_ROLE) {
+    Facilitator storage facilitator = _facilitators[facilitatorAddress];
+    require(bytes(facilitator.label).length == 0, 'FACILITATOR_ALREADY_EXISTS');
+    require(bytes(facilitatorLabel).length > 0, 'INVALID_LABEL');
+
+    facilitator.label = facilitatorLabel;
+    facilitator.bucketCapacity = bucketCapacity;
+
+    _facilitatorsList.add(facilitatorAddress);
+
+    emit FacilitatorAdded(
+      facilitatorAddress,
+      keccak256(abi.encodePacked(facilitatorLabel)),
+      bucketCapacity
+    );
+  }
+
+  /// @inheritdoc IGhoToken
+  function removeFacilitator(
+    address facilitatorAddress
+  ) external onlyRole(FACILITATOR_MANAGER_ROLE) {
+    require(
+      bytes(_facilitators[facilitatorAddress].label).length > 0,
+      'FACILITATOR_DOES_NOT_EXIST'
+    );
+    require(
+      _facilitators[facilitatorAddress].bucketLevel == 0,
+      'FACILITATOR_BUCKET_LEVEL_NOT_ZERO'
+    );
+
+    delete _facilitators[facilitatorAddress];
+    _facilitatorsList.remove(facilitatorAddress);
+
+    emit FacilitatorRemoved(facilitatorAddress);
+  }
+
+  /// @inheritdoc IGhoToken
+  function setFacilitatorBucketCapacity(
+    address facilitator,
+    uint128 newCapacity
+  ) external onlyRole(BUCKET_MANAGER_ROLE) {
+    require(bytes(_facilitators[facilitator].label).length > 0, 'FACILITATOR_DOES_NOT_EXIST');
+
+    uint256 oldCapacity = _facilitators[facilitator].bucketCapacity;
+    _facilitators[facilitator].bucketCapacity = newCapacity;
+
+    emit FacilitatorBucketCapacityUpdated(facilitator, oldCapacity, newCapacity);
+  }
+
+  /// @inheritdoc IGhoToken
+  function getFacilitator(address facilitator) external view returns (Facilitator memory) {
+    return _facilitators[facilitator];
+  }
+
+  /// @inheritdoc IGhoToken
+  function getFacilitatorBucket(address facilitator) external view returns (uint256, uint256) {
+    return (_facilitators[facilitator].bucketCapacity, _facilitators[facilitator].bucketLevel);
+  }
+
+  /// @inheritdoc IGhoToken
+  function getFacilitatorsList() external view returns (address[] memory) {
+    return _facilitatorsList.values();
+  }
+
+  /**
+   * @notice Returns the revision number
+   * @return The revision number
+   */
+  function REVISION() public pure virtual returns (uint256) {
+    return 1;
+  }
+
+  /// @inheritdoc VersionedInitializable
+  function getRevision() internal pure virtual override returns (uint256) {
+    return REVISION();
+  }
+}

--- a/src/contracts/gho/UpgradeableGhoToken.sol
+++ b/src/contracts/gho/UpgradeableGhoToken.sol
@@ -37,7 +37,7 @@ contract UpgradeableGhoToken is VersionedInitializable, UpgradeableERC20, Access
   function initialize(address admin) public virtual initializer {
     _ERC20_init('Gho Token', 'GHO');
 
-    _setupRole(DEFAULT_ADMIN_ROLE, admin);
+    _grantRole(DEFAULT_ADMIN_ROLE, admin);
   }
 
   /// @inheritdoc IGhoToken

--- a/src/test/TestGhoSteward.t.sol
+++ b/src/test/TestGhoSteward.t.sol
@@ -54,8 +54,8 @@ contract TestGhoSteward is TestGhoBase {
   }
 
   function testRevertExtendStewardExpiration() public {
+    vm.expectRevert(OwnableErrorsLib.CALLER_NOT_OWNER());
     vm.prank(ALICE);
-    vm.expectRevert('Ownable: caller is not the owner');
     GHO_STEWARD.extendStewardExpiration();
   }
 

--- a/src/test/TestGhoStewardV2.t.sol
+++ b/src/test/TestGhoStewardV2.t.sol
@@ -719,7 +719,7 @@ contract TestGhoStewardV2 is TestGhoBase {
   }
 
   function testRevertSetControlledFacilitatorIfUnauthorized() public {
-    vm.expectRevert('Ownable: caller is not the owner');
+    vm.expectRevert(OwnableErrorsLib.CALLER_NOT_OWNER());
     vm.prank(RISK_COUNCIL);
     address[] memory newGsmList = new address[](1);
     newGsmList[0] = address(GHO_GSM_4626);

--- a/src/test/TestGhoToken.t.sol
+++ b/src/test/TestGhoToken.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import './TestGhoBase.t.sol';
-import '@openzeppelin/contracts/utils/Strings.sol';
 
 contract TestGhoToken is TestGhoBase {
   function testConstructor() public {
@@ -73,8 +72,8 @@ contract TestGhoToken is TestGhoBase {
 
   function testAddFacilitatorWithRole() public {
     vm.expectEmit(true, true, true, true, address(GHO_TOKEN));
-    emit RoleGranted(GHO_TOKEN.FACILITATOR_MANAGER_ROLE(), ALICE, address(this));
-    GHO_TOKEN.grantRole(GHO_TOKEN.FACILITATOR_MANAGER_ROLE(), ALICE);
+    emit RoleGranted(GHO_TOKEN_FACILITATOR_MANAGER_ROLE, ALICE, address(this));
+    GHO_TOKEN.grantRole(GHO_TOKEN_FACILITATOR_MANAGER_ROLE, ALICE);
     vm.prank(ALICE);
     vm.expectEmit(true, true, false, true, address(GHO_TOKEN));
     emit FacilitatorAdded(ALICE, keccak256(abi.encodePacked('Alice')), DEFAULT_CAPACITY);
@@ -92,14 +91,10 @@ contract TestGhoToken is TestGhoBase {
   }
 
   function testRevertAddFacilitatorNoRole() public {
-    bytes memory revertMsg = abi.encodePacked(
-      'AccessControl: account ',
-      Strings.toHexString(ALICE),
-      ' is missing role ',
-      Strings.toHexString(uint256(FACILITATOR_MANAGER_ROLE), 32)
+    vm.expectRevert(
+      AccessControlErrorsLib.MISSING_ROLE(GHO_TOKEN_FACILITATOR_MANAGER_ROLE, address(ALICE))
     );
     vm.prank(ALICE);
-    vm.expectRevert(revertMsg);
     GHO_TOKEN.addFacilitator(ALICE, 'Alice', DEFAULT_CAPACITY);
   }
 
@@ -116,8 +111,8 @@ contract TestGhoToken is TestGhoBase {
 
   function testSetNewBucketCapacityAsManager() public {
     vm.expectEmit(true, true, true, true, address(GHO_TOKEN));
-    emit RoleGranted(GHO_TOKEN.BUCKET_MANAGER_ROLE(), ALICE, address(this));
-    GHO_TOKEN.grantRole(GHO_TOKEN.BUCKET_MANAGER_ROLE(), ALICE);
+    emit RoleGranted(GHO_TOKEN_BUCKET_MANAGER_ROLE, ALICE, address(this));
+    GHO_TOKEN.grantRole(GHO_TOKEN_BUCKET_MANAGER_ROLE, ALICE);
     vm.prank(ALICE);
     vm.expectEmit(true, false, false, true, address(GHO_TOKEN));
     emit FacilitatorBucketCapacityUpdated(address(GHO_ATOKEN), DEFAULT_CAPACITY, 0);
@@ -125,14 +120,10 @@ contract TestGhoToken is TestGhoBase {
   }
 
   function testRevertSetNewBucketCapacityNoRole() public {
-    bytes memory revertMsg = abi.encodePacked(
-      'AccessControl: account ',
-      Strings.toHexString(ALICE),
-      ' is missing role ',
-      Strings.toHexString(uint256(BUCKET_MANAGER_ROLE), 32)
+    vm.expectRevert(
+      AccessControlErrorsLib.MISSING_ROLE(GHO_TOKEN_BUCKET_MANAGER_ROLE, address(ALICE))
     );
     vm.prank(ALICE);
-    vm.expectRevert(revertMsg);
     GHO_TOKEN.setFacilitatorBucketCapacity(address(GHO_ATOKEN), 0);
   }
 
@@ -155,8 +146,8 @@ contract TestGhoToken is TestGhoBase {
 
   function testRemoveFacilitatorWithRole() public {
     vm.expectEmit(true, true, true, true, address(GHO_TOKEN));
-    emit RoleGranted(GHO_TOKEN.FACILITATOR_MANAGER_ROLE(), ALICE, address(this));
-    GHO_TOKEN.grantRole(GHO_TOKEN.FACILITATOR_MANAGER_ROLE(), ALICE);
+    emit RoleGranted(GHO_TOKEN_FACILITATOR_MANAGER_ROLE, ALICE, address(this));
+    GHO_TOKEN.grantRole(GHO_TOKEN_FACILITATOR_MANAGER_ROLE, ALICE);
     vm.prank(ALICE);
     vm.expectEmit(true, false, false, true, address(GHO_TOKEN));
     emit FacilitatorRemoved(address(GHO_ATOKEN));
@@ -164,14 +155,10 @@ contract TestGhoToken is TestGhoBase {
   }
 
   function testRevertRemoveFacilitatorNoRole() public {
-    bytes memory revertMsg = abi.encodePacked(
-      'AccessControl: account ',
-      Strings.toHexString(ALICE),
-      ' is missing role ',
-      Strings.toHexString(uint256(FACILITATOR_MANAGER_ROLE), 32)
+    vm.expectRevert(
+      AccessControlErrorsLib.MISSING_ROLE(GHO_TOKEN_FACILITATOR_MANAGER_ROLE, address(ALICE))
     );
     vm.prank(ALICE);
-    vm.expectRevert(revertMsg);
     GHO_TOKEN.removeFacilitator(address(GHO_ATOKEN));
   }
 

--- a/src/test/TestGhoToken.t.sol
+++ b/src/test/TestGhoToken.t.sol
@@ -8,8 +8,8 @@ contract TestGhoToken is TestGhoBase {
   function testConstructor() public {
     GhoToken ghoToken = new GhoToken(address(this));
     vm.expectEmit(true, true, true, true, address(GHO_TOKEN));
-    emit RoleGranted(GHO_TOKEN.DEFAULT_ADMIN_ROLE(), msg.sender, address(this));
-    GHO_TOKEN.grantRole(GHO_TOKEN.DEFAULT_ADMIN_ROLE(), msg.sender);
+    emit RoleGranted(DEFAULT_ADMIN_ROLE, msg.sender, address(this));
+    GHO_TOKEN.grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
     assertEq(ghoToken.name(), 'Gho Token', 'Wrong default ERC20 name');
     assertEq(ghoToken.symbol(), 'GHO', 'Wrong default ERC20 symbol');
     assertEq(ghoToken.decimals(), 18, 'Wrong default ERC20 decimals');

--- a/src/test/TestUpgradeableGhoToken.t.sol
+++ b/src/test/TestUpgradeableGhoToken.t.sol
@@ -1,0 +1,480 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import './TestGhoBase.t.sol';
+import '@openzeppelin/contracts/utils/Strings.sol';
+
+contract TestUpgradeableGhoTokenSetup is TestGhoBase {
+  address internal PROXY_ADMIN = makeAddr('PROXY_ADMIN');
+
+  UpgradeableGhoToken internal ghoToken;
+
+  function setUp() public virtual {
+    UpgradeableGhoToken ghoTokenImple = new UpgradeableGhoToken();
+
+    // imple init
+    ghoTokenImple.initialize(address(this));
+
+    // proxy deploy and init
+    bytes memory ghoTokenImpleParams = abi.encodeWithSignature(
+      'initialize(address)',
+      address(this)
+    );
+    TransparentUpgradeableProxy ghoTokenProxy = new TransparentUpgradeableProxy(
+      address(ghoTokenImple),
+      PROXY_ADMIN,
+      ghoTokenImpleParams
+    );
+
+    ghoToken = UpgradeableGhoToken(address(ghoTokenProxy));
+  }
+}
+
+contract TestUpgradeableGhoToken is TestUpgradeableGhoTokenSetup {
+  function setUp() public override {
+    super.setUp();
+
+    // Grant
+    ghoToken.grantRole(GHO_TOKEN_FACILITATOR_MANAGER_ROLE, address(this));
+    ghoToken.grantRole(GHO_TOKEN_BUCKET_MANAGER_ROLE, address(this));
+
+    // Add Aave as Facilitator
+    ghoToken.addFacilitator(address(GHO_ATOKEN), 'Aave V3 Pool', DEFAULT_CAPACITY);
+    // Add Faucet ad Facilitator
+    ghoToken.addFacilitator(FAUCET, 'Faucet Facilitator', type(uint128).max);
+  }
+
+  function testInit() public {
+    UpgradeableGhoToken ghoTokenImple = new UpgradeableGhoToken();
+    // imple init
+    ghoTokenImple.initialize(address(this));
+    // proxy deploy and init
+    bytes memory ghoTokenImpleParams = abi.encodeWithSignature(
+      'initialize(address)',
+      address(this)
+    );
+
+    vm.expectEmit(true, true, true, true);
+    emit RoleGranted(DEFAULT_ADMIN_ROLE, address(this), address(this));
+    TransparentUpgradeableProxy ghoTokenProxy = new TransparentUpgradeableProxy(
+      address(ghoTokenImple),
+      PROXY_ADMIN,
+      ghoTokenImpleParams
+    );
+
+    // Implementation asserts
+    assertEq(ghoTokenImple.decimals(), 18, 'Wrong default ERC20 decimals');
+    vm.expectRevert('Contract instance has already been initialized');
+    ghoTokenImple.initialize(address(this));
+
+    // Proxy asserts
+    UpgradeableGhoToken token = UpgradeableGhoToken(address(ghoTokenProxy));
+
+    assertEq(token.name(), 'Gho Token', 'Wrong default ERC20 name');
+    assertEq(token.symbol(), 'GHO', 'Wrong default ERC20 symbol');
+    assertEq(token.decimals(), 18, 'Wrong default ERC20 decimals');
+    assertEq(token.getFacilitatorsList().length, 0, 'Facilitator list not empty');
+  }
+
+  function testGetFacilitatorData() public {
+    IGhoToken.Facilitator memory data = ghoToken.getFacilitator(address(GHO_ATOKEN));
+    assertEq(data.label, 'Aave V3 Pool', 'Unexpected facilitator label');
+    assertEq(data.bucketCapacity, DEFAULT_CAPACITY, 'Unexpected bucket capacity');
+    assertEq(data.bucketLevel, 0, 'Unexpected bucket level');
+  }
+
+  function testGetNonFacilitatorData() public {
+    IGhoToken.Facilitator memory data = ghoToken.getFacilitator(ALICE);
+    assertEq(data.label, '', 'Unexpected facilitator label');
+    assertEq(data.bucketCapacity, 0, 'Unexpected bucket capacity');
+    assertEq(data.bucketLevel, 0, 'Unexpected bucket level');
+  }
+
+  function testGetFacilitatorBucket() public {
+    (uint256 capacity, uint256 level) = ghoToken.getFacilitatorBucket(address(GHO_ATOKEN));
+    assertEq(capacity, DEFAULT_CAPACITY, 'Unexpected bucket capacity');
+    assertEq(level, 0, 'Unexpected bucket level');
+  }
+
+  function testGetNonFacilitatorBucket() public {
+    (uint256 capacity, uint256 level) = ghoToken.getFacilitatorBucket(ALICE);
+    assertEq(capacity, 0, 'Unexpected bucket capacity');
+    assertEq(level, 0, 'Unexpected bucket level');
+  }
+
+  function testGetPopulatedFacilitatorsList() public {
+    address[] memory facilitatorList = ghoToken.getFacilitatorsList();
+    assertEq(facilitatorList.length, 2, 'Unexpected number of facilitators');
+    assertEq(facilitatorList[0], address(GHO_ATOKEN), 'Unexpected address for mock facilitator 1');
+    assertEq(facilitatorList[1], FAUCET, 'Unexpected address for mock facilitator 5');
+  }
+
+  function testAddFacilitator() public {
+    vm.expectEmit(true, true, false, true, address(ghoToken));
+    emit FacilitatorAdded(ALICE, keccak256(abi.encodePacked('Alice')), DEFAULT_CAPACITY);
+    ghoToken.addFacilitator(ALICE, 'Alice', DEFAULT_CAPACITY);
+  }
+
+  function testAddFacilitatorWithRole() public {
+    vm.expectEmit(true, true, true, true, address(ghoToken));
+    emit RoleGranted(ghoToken.FACILITATOR_MANAGER_ROLE(), ALICE, address(this));
+    ghoToken.grantRole(ghoToken.FACILITATOR_MANAGER_ROLE(), ALICE);
+    vm.prank(ALICE);
+    vm.expectEmit(true, true, false, true, address(ghoToken));
+    emit FacilitatorAdded(ALICE, keccak256(abi.encodePacked('Alice')), DEFAULT_CAPACITY);
+    ghoToken.addFacilitator(ALICE, 'Alice', DEFAULT_CAPACITY);
+  }
+
+  function testRevertAddExistingFacilitator() public {
+    vm.expectRevert('FACILITATOR_ALREADY_EXISTS');
+    ghoToken.addFacilitator(address(GHO_ATOKEN), 'Aave V3 Pool', DEFAULT_CAPACITY);
+  }
+
+  function testRevertAddFacilitatorNoLabel() public {
+    vm.expectRevert('INVALID_LABEL');
+    ghoToken.addFacilitator(ALICE, '', DEFAULT_CAPACITY);
+  }
+
+  function testRevertAddFacilitatorNoRole() public {
+    bytes memory revertMsg = abi.encodePacked(
+      'AccessControl: account ',
+      Strings.toHexString(ALICE),
+      ' is missing role ',
+      Strings.toHexString(uint256(FACILITATOR_MANAGER_ROLE), 32)
+    );
+    vm.prank(ALICE);
+    vm.expectRevert(revertMsg);
+    ghoToken.addFacilitator(ALICE, 'Alice', DEFAULT_CAPACITY);
+  }
+
+  function testRevertSetBucketCapacityNonFacilitator() public {
+    vm.expectRevert('FACILITATOR_DOES_NOT_EXIST');
+    ghoToken.setFacilitatorBucketCapacity(ALICE, DEFAULT_CAPACITY);
+  }
+
+  function testSetNewBucketCapacity() public {
+    vm.expectEmit(true, false, false, true, address(ghoToken));
+    emit FacilitatorBucketCapacityUpdated(address(GHO_ATOKEN), DEFAULT_CAPACITY, 0);
+    ghoToken.setFacilitatorBucketCapacity(address(GHO_ATOKEN), 0);
+  }
+
+  function testSetNewBucketCapacityAsManager() public {
+    vm.expectEmit(true, true, true, true, address(ghoToken));
+    emit RoleGranted(ghoToken.BUCKET_MANAGER_ROLE(), ALICE, address(this));
+    ghoToken.grantRole(ghoToken.BUCKET_MANAGER_ROLE(), ALICE);
+    vm.prank(ALICE);
+    vm.expectEmit(true, false, false, true, address(ghoToken));
+    emit FacilitatorBucketCapacityUpdated(address(GHO_ATOKEN), DEFAULT_CAPACITY, 0);
+    ghoToken.setFacilitatorBucketCapacity(address(GHO_ATOKEN), 0);
+  }
+
+  function testRevertSetNewBucketCapacityNoRole() public {
+    bytes memory revertMsg = abi.encodePacked(
+      'AccessControl: account ',
+      Strings.toHexString(ALICE),
+      ' is missing role ',
+      Strings.toHexString(uint256(BUCKET_MANAGER_ROLE), 32)
+    );
+    vm.prank(ALICE);
+    vm.expectRevert(revertMsg);
+    ghoToken.setFacilitatorBucketCapacity(address(GHO_ATOKEN), 0);
+  }
+
+  function testRevertRemoveNonFacilitator() public {
+    vm.expectRevert('FACILITATOR_DOES_NOT_EXIST');
+    ghoToken.removeFacilitator(ALICE);
+  }
+
+  function testRevertRemoveFacilitatorNonZeroBucket() public {
+    vm.prank(FAUCET);
+    ghoToken.mint(ALICE, 1);
+
+    vm.expectRevert('FACILITATOR_BUCKET_LEVEL_NOT_ZERO');
+    ghoToken.removeFacilitator(FAUCET);
+  }
+
+  function testRemoveFacilitator() public {
+    vm.expectEmit(true, false, false, true, address(ghoToken));
+    emit FacilitatorRemoved(address(GHO_ATOKEN));
+    ghoToken.removeFacilitator(address(GHO_ATOKEN));
+  }
+
+  function testRemoveFacilitatorWithRole() public {
+    vm.expectEmit(true, true, true, true, address(ghoToken));
+    emit RoleGranted(ghoToken.FACILITATOR_MANAGER_ROLE(), ALICE, address(this));
+    ghoToken.grantRole(ghoToken.FACILITATOR_MANAGER_ROLE(), ALICE);
+    vm.prank(ALICE);
+    vm.expectEmit(true, false, false, true, address(ghoToken));
+    emit FacilitatorRemoved(address(GHO_ATOKEN));
+    ghoToken.removeFacilitator(address(GHO_ATOKEN));
+  }
+
+  function testRevertRemoveFacilitatorNoRole() public {
+    bytes memory revertMsg = abi.encodePacked(
+      'AccessControl: account ',
+      Strings.toHexString(ALICE),
+      ' is missing role ',
+      Strings.toHexString(uint256(FACILITATOR_MANAGER_ROLE), 32)
+    );
+    vm.prank(ALICE);
+    vm.expectRevert(revertMsg);
+    ghoToken.removeFacilitator(address(GHO_ATOKEN));
+  }
+
+  function testRevertMintBadFacilitator() public {
+    vm.prank(ALICE);
+    vm.expectRevert('FACILITATOR_BUCKET_CAPACITY_EXCEEDED');
+    ghoToken.mint(ALICE, DEFAULT_BORROW_AMOUNT);
+  }
+
+  function testRevertMintExceedCapacity() public {
+    vm.prank(address(GHO_ATOKEN));
+    vm.expectRevert('FACILITATOR_BUCKET_CAPACITY_EXCEEDED');
+    ghoToken.mint(ALICE, DEFAULT_CAPACITY + 1);
+  }
+
+  function testMint() public {
+    vm.prank(address(GHO_ATOKEN));
+    vm.expectEmit(true, true, false, true, address(ghoToken));
+    emit Transfer(address(0), ALICE, DEFAULT_CAPACITY);
+    vm.expectEmit(true, false, false, true, address(ghoToken));
+    emit FacilitatorBucketLevelUpdated(address(GHO_ATOKEN), 0, DEFAULT_CAPACITY);
+    ghoToken.mint(ALICE, DEFAULT_CAPACITY);
+  }
+
+  function testRevertZeroMint() public {
+    vm.prank(address(GHO_ATOKEN));
+    vm.expectRevert('INVALID_MINT_AMOUNT');
+    ghoToken.mint(ALICE, 0);
+  }
+
+  function testRevertZeroBurn() public {
+    vm.prank(address(GHO_ATOKEN));
+    vm.expectRevert('INVALID_BURN_AMOUNT');
+    ghoToken.burn(0);
+  }
+
+  function testRevertBurnMoreThanMinted() public {
+    vm.prank(address(GHO_ATOKEN));
+    vm.expectEmit(true, false, false, true, address(ghoToken));
+    emit FacilitatorBucketLevelUpdated(address(GHO_ATOKEN), 0, DEFAULT_CAPACITY);
+    ghoToken.mint(address(GHO_ATOKEN), DEFAULT_CAPACITY);
+
+    vm.prank(address(GHO_ATOKEN));
+    vm.expectRevert(stdError.arithmeticError);
+    ghoToken.burn(DEFAULT_CAPACITY + 1);
+  }
+
+  function testRevertBurnOthersTokens() public {
+    vm.prank(address(GHO_ATOKEN));
+    vm.expectEmit(true, true, false, true, address(ghoToken));
+    emit Transfer(address(0), ALICE, DEFAULT_CAPACITY);
+    vm.expectEmit(true, false, false, true, address(ghoToken));
+    emit FacilitatorBucketLevelUpdated(address(GHO_ATOKEN), 0, DEFAULT_CAPACITY);
+    ghoToken.mint(ALICE, DEFAULT_CAPACITY);
+
+    vm.prank(address(GHO_ATOKEN));
+    vm.expectRevert(stdError.arithmeticError);
+    ghoToken.burn(DEFAULT_CAPACITY);
+  }
+
+  function testBurn() public {
+    vm.prank(address(GHO_ATOKEN));
+    vm.expectEmit(true, true, false, true, address(ghoToken));
+    emit Transfer(address(0), address(GHO_ATOKEN), DEFAULT_CAPACITY);
+    vm.expectEmit(true, false, false, true, address(ghoToken));
+    emit FacilitatorBucketLevelUpdated(address(GHO_ATOKEN), 0, DEFAULT_CAPACITY);
+    ghoToken.mint(address(GHO_ATOKEN), DEFAULT_CAPACITY);
+
+    vm.prank(address(GHO_ATOKEN));
+    vm.expectEmit(true, false, false, true, address(ghoToken));
+    emit FacilitatorBucketLevelUpdated(
+      address(GHO_ATOKEN),
+      DEFAULT_CAPACITY,
+      DEFAULT_CAPACITY - DEFAULT_BORROW_AMOUNT
+    );
+    ghoToken.burn(DEFAULT_BORROW_AMOUNT);
+  }
+
+  function testOffboardFacilitator() public {
+    // Onboard facilitator
+    vm.expectEmit(true, true, false, true, address(ghoToken));
+    emit FacilitatorAdded(ALICE, keccak256(abi.encodePacked('Alice')), DEFAULT_CAPACITY);
+    ghoToken.addFacilitator(ALICE, 'Alice', DEFAULT_CAPACITY);
+
+    // Facilitator mints half of its capacity
+    vm.prank(ALICE);
+    ghoToken.mint(ALICE, DEFAULT_CAPACITY / 2);
+    (uint256 bucketCapacity, uint256 bucketLevel) = ghoToken.getFacilitatorBucket(ALICE);
+    assertEq(bucketCapacity, DEFAULT_CAPACITY, 'Unexpected bucket capacity of facilitator');
+    assertEq(bucketLevel, DEFAULT_CAPACITY / 2, 'Unexpected bucket level of facilitator');
+
+    // Facilitator cannot be removed
+    vm.expectRevert('FACILITATOR_BUCKET_LEVEL_NOT_ZERO');
+    ghoToken.removeFacilitator(ALICE);
+
+    // Facilitator Bucket Capacity set to 0
+    ghoToken.setFacilitatorBucketCapacity(ALICE, 0);
+
+    // Facilitator cannot mint more and is expected to burn remaining level
+    vm.prank(ALICE);
+    vm.expectRevert('FACILITATOR_BUCKET_CAPACITY_EXCEEDED');
+    ghoToken.mint(ALICE, 1);
+
+    vm.prank(ALICE);
+    ghoToken.burn(bucketLevel);
+
+    // Facilitator can be removed with 0 bucket level
+    vm.expectEmit(true, false, false, true, address(ghoToken));
+    emit FacilitatorRemoved(address(ALICE));
+    ghoToken.removeFacilitator(address(ALICE));
+  }
+
+  function testDomainSeparator() public {
+    bytes32 EIP712_DOMAIN = keccak256(
+      'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'
+    );
+    bytes memory EIP712_REVISION = bytes('1');
+    bytes32 expected = keccak256(
+      abi.encode(
+        EIP712_DOMAIN,
+        keccak256(bytes(ghoToken.name())),
+        keccak256(EIP712_REVISION),
+        block.chainid,
+        address(ghoToken)
+      )
+    );
+    bytes32 result = ghoToken.DOMAIN_SEPARATOR();
+    assertEq(result, expected, 'Unexpected domain separator');
+  }
+
+  function testDomainSeparatorNewChain() public {
+    vm.chainId(31338);
+    bytes32 EIP712_DOMAIN = keccak256(
+      'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'
+    );
+    bytes memory EIP712_REVISION = bytes('1');
+    bytes32 expected = keccak256(
+      abi.encode(
+        EIP712_DOMAIN,
+        keccak256(bytes(ghoToken.name())),
+        keccak256(EIP712_REVISION),
+        block.chainid,
+        address(ghoToken)
+      )
+    );
+    bytes32 result = ghoToken.DOMAIN_SEPARATOR();
+    assertEq(result, expected, 'Unexpected domain separator');
+  }
+
+  function testPermitAndVerifyNonce() public {
+    (address david, uint256 davidKey) = makeAddrAndKey('david');
+    ghoFaucet(david, 1e18);
+    bytes32 PERMIT_TYPEHASH = 0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
+    bytes32 innerHash = keccak256(abi.encode(PERMIT_TYPEHASH, david, BOB, 1e18, 0, 1 hours));
+    bytes32 outerHash = keccak256(
+      abi.encodePacked('\x19\x01', ghoToken.DOMAIN_SEPARATOR(), innerHash)
+    );
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(davidKey, outerHash);
+    ghoToken.permit(david, BOB, 1e18, 1 hours, v, r, s);
+
+    assertEq(ghoToken.allowance(david, BOB), 1e18, 'Unexpected allowance');
+    assertEq(ghoToken.nonces(david), 1, 'Unexpected nonce');
+  }
+
+  function testRevertPermitInvalidSignature() public {
+    (, uint256 davidKey) = makeAddrAndKey('david');
+    bytes32 PERMIT_TYPEHASH = 0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
+    bytes32 innerHash = keccak256(abi.encode(PERMIT_TYPEHASH, ALICE, BOB, 1e18, 0, 1 hours));
+    bytes32 outerHash = keccak256(
+      abi.encodePacked('\x19\x01', ghoToken.DOMAIN_SEPARATOR(), innerHash)
+    );
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(davidKey, outerHash);
+    vm.expectRevert(bytes('INVALID_SIGNER'));
+    ghoToken.permit(ALICE, BOB, 1e18, 1 hours, v, r, s);
+  }
+
+  function testRevertPermitInvalidDeadline() public {
+    vm.expectRevert(bytes('PERMIT_DEADLINE_EXPIRED'));
+    ghoToken.permit(ALICE, BOB, 1e18, block.timestamp - 1, 0, 0, 0);
+  }
+}
+
+contract TestUpgradeableGhoTokenUpgrade is TestUpgradeableGhoTokenSetup {
+  function testInitialization() public {
+    // Upgradeability
+    assertEq(ghoToken.REVISION(), 1);
+    vm.prank(PROXY_ADMIN);
+    (bool ok, bytes memory result) = address(ghoToken).staticcall(
+      abi.encodeWithSelector(TransparentUpgradeableProxy.admin.selector)
+    );
+    assertTrue(ok, 'proxy admin fetch failed');
+    address decodedProxyAdmin = abi.decode(result, (address));
+    assertEq(decodedProxyAdmin, PROXY_ADMIN, 'proxy admin is wrong');
+    assertEq(decodedProxyAdmin, getProxyAdminAddress(address(ghoToken)), 'proxy admin is wrong');
+
+    // Implementation
+    vm.prank(PROXY_ADMIN);
+    (ok, result) = address(ghoToken).staticcall(
+      abi.encodeWithSelector(TransparentUpgradeableProxy.implementation.selector)
+    );
+    assertTrue(ok, 'proxy implementation fetch failed');
+    address decodedImple = abi.decode(result, (address));
+    assertEq(
+      decodedImple,
+      getProxyImplementationAddress(address(ghoToken)),
+      'proxy implementation is wrong'
+    );
+
+    assertEq(UpgradeableGhoToken(decodedImple).decimals(), 18, 'Wrong default ERC20 decimals');
+    vm.expectRevert('Contract instance has already been initialized');
+    UpgradeableGhoToken(decodedImple).initialize(address(this));
+
+    // Proxy
+    assertEq(ghoToken.name(), 'Gho Token', 'Wrong default ERC20 name');
+    assertEq(ghoToken.symbol(), 'GHO', 'Wrong default ERC20 symbol');
+    assertEq(ghoToken.decimals(), 18, 'Wrong default ERC20 decimals');
+    assertEq(ghoToken.totalSupply(), 0, 'Wrong total supply');
+    assertEq(ghoToken.getFacilitatorsList().length, 0, 'Facilitator list not empty');
+  }
+
+  function testUpgrade() public {
+    MockUpgradeable newImpl = new MockUpgradeable();
+    bytes memory mockImpleParams = abi.encodeWithSignature('initialize()');
+    vm.prank(PROXY_ADMIN);
+    TransparentUpgradeableProxy(payable(address(ghoToken))).upgradeToAndCall(
+      address(newImpl),
+      mockImpleParams
+    );
+
+    assertEq(ghoToken.REVISION(), 2);
+  }
+
+  function testRevertUpgradeUnauthorized() public {
+    vm.expectRevert();
+    TransparentUpgradeableProxy(payable(address(ghoToken))).upgradeToAndCall(address(0), bytes(''));
+
+    vm.expectRevert();
+    TransparentUpgradeableProxy(payable(address(ghoToken))).upgradeTo(address(0));
+  }
+
+  function testChangeAdmin() public {
+    assertEq(getProxyAdminAddress(address(ghoToken)), PROXY_ADMIN);
+
+    address newAdmin = makeAddr('newAdmin');
+    vm.prank(PROXY_ADMIN);
+    TransparentUpgradeableProxy(payable(address(ghoToken))).changeAdmin(newAdmin);
+
+    assertEq(getProxyAdminAddress(address(ghoToken)), newAdmin, 'Admin change failed');
+  }
+
+  function testChangeAdminUnauthorized() public {
+    assertEq(getProxyAdminAddress(address(ghoToken)), PROXY_ADMIN);
+
+    address newAdmin = makeAddr('newAdmin');
+    vm.expectRevert();
+    TransparentUpgradeableProxy(payable(address(ghoToken))).changeAdmin(newAdmin);
+
+    assertEq(getProxyAdminAddress(address(ghoToken)), PROXY_ADMIN, 'Unauthorized admin change');
+  }
+}

--- a/src/test/TestUpgradeableGhoToken.t.sol
+++ b/src/test/TestUpgradeableGhoToken.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import './TestGhoBase.t.sol';
-import '@openzeppelin/contracts/utils/Strings.sol';
 
 contract TestUpgradeableGhoTokenSetup is TestGhoBase {
   address internal PROXY_ADMIN = makeAddr('PROXY_ADMIN');
@@ -117,8 +116,8 @@ contract TestUpgradeableGhoToken is TestUpgradeableGhoTokenSetup {
 
   function testAddFacilitatorWithRole() public {
     vm.expectEmit(true, true, true, true, address(ghoToken));
-    emit RoleGranted(ghoToken.FACILITATOR_MANAGER_ROLE(), ALICE, address(this));
-    ghoToken.grantRole(ghoToken.FACILITATOR_MANAGER_ROLE(), ALICE);
+    emit RoleGranted(GHO_TOKEN_FACILITATOR_MANAGER_ROLE, ALICE, address(this));
+    ghoToken.grantRole(GHO_TOKEN_FACILITATOR_MANAGER_ROLE, ALICE);
     vm.prank(ALICE);
     vm.expectEmit(true, true, false, true, address(ghoToken));
     emit FacilitatorAdded(ALICE, keccak256(abi.encodePacked('Alice')), DEFAULT_CAPACITY);
@@ -136,14 +135,10 @@ contract TestUpgradeableGhoToken is TestUpgradeableGhoTokenSetup {
   }
 
   function testRevertAddFacilitatorNoRole() public {
-    bytes memory revertMsg = abi.encodePacked(
-      'AccessControl: account ',
-      Strings.toHexString(ALICE),
-      ' is missing role ',
-      Strings.toHexString(uint256(FACILITATOR_MANAGER_ROLE), 32)
+    vm.expectRevert(
+      AccessControlErrorsLib.MISSING_ROLE(GHO_TOKEN_FACILITATOR_MANAGER_ROLE, address(ALICE))
     );
     vm.prank(ALICE);
-    vm.expectRevert(revertMsg);
     ghoToken.addFacilitator(ALICE, 'Alice', DEFAULT_CAPACITY);
   }
 
@@ -160,8 +155,8 @@ contract TestUpgradeableGhoToken is TestUpgradeableGhoTokenSetup {
 
   function testSetNewBucketCapacityAsManager() public {
     vm.expectEmit(true, true, true, true, address(ghoToken));
-    emit RoleGranted(ghoToken.BUCKET_MANAGER_ROLE(), ALICE, address(this));
-    ghoToken.grantRole(ghoToken.BUCKET_MANAGER_ROLE(), ALICE);
+    emit RoleGranted(GHO_TOKEN_BUCKET_MANAGER_ROLE, ALICE, address(this));
+    ghoToken.grantRole(GHO_TOKEN_BUCKET_MANAGER_ROLE, ALICE);
     vm.prank(ALICE);
     vm.expectEmit(true, false, false, true, address(ghoToken));
     emit FacilitatorBucketCapacityUpdated(address(GHO_ATOKEN), DEFAULT_CAPACITY, 0);
@@ -169,14 +164,10 @@ contract TestUpgradeableGhoToken is TestUpgradeableGhoTokenSetup {
   }
 
   function testRevertSetNewBucketCapacityNoRole() public {
-    bytes memory revertMsg = abi.encodePacked(
-      'AccessControl: account ',
-      Strings.toHexString(ALICE),
-      ' is missing role ',
-      Strings.toHexString(uint256(BUCKET_MANAGER_ROLE), 32)
+    vm.expectRevert(
+      AccessControlErrorsLib.MISSING_ROLE(GHO_TOKEN_BUCKET_MANAGER_ROLE, address(ALICE))
     );
     vm.prank(ALICE);
-    vm.expectRevert(revertMsg);
     ghoToken.setFacilitatorBucketCapacity(address(GHO_ATOKEN), 0);
   }
 
@@ -201,8 +192,8 @@ contract TestUpgradeableGhoToken is TestUpgradeableGhoTokenSetup {
 
   function testRemoveFacilitatorWithRole() public {
     vm.expectEmit(true, true, true, true, address(ghoToken));
-    emit RoleGranted(ghoToken.FACILITATOR_MANAGER_ROLE(), ALICE, address(this));
-    ghoToken.grantRole(ghoToken.FACILITATOR_MANAGER_ROLE(), ALICE);
+    emit RoleGranted(GHO_TOKEN_FACILITATOR_MANAGER_ROLE, ALICE, address(this));
+    ghoToken.grantRole(GHO_TOKEN_FACILITATOR_MANAGER_ROLE, ALICE);
     vm.prank(ALICE);
     vm.expectEmit(true, false, false, true, address(ghoToken));
     emit FacilitatorRemoved(address(GHO_ATOKEN));
@@ -210,14 +201,10 @@ contract TestUpgradeableGhoToken is TestUpgradeableGhoTokenSetup {
   }
 
   function testRevertRemoveFacilitatorNoRole() public {
-    bytes memory revertMsg = abi.encodePacked(
-      'AccessControl: account ',
-      Strings.toHexString(ALICE),
-      ' is missing role ',
-      Strings.toHexString(uint256(FACILITATOR_MANAGER_ROLE), 32)
+    vm.expectRevert(
+      AccessControlErrorsLib.MISSING_ROLE(GHO_TOKEN_FACILITATOR_MANAGER_ROLE, address(ALICE))
     );
     vm.prank(ALICE);
-    vm.expectRevert(revertMsg);
     ghoToken.removeFacilitator(address(GHO_ATOKEN));
   }
 

--- a/src/test/helpers/Constants.sol
+++ b/src/test/helpers/Constants.sol
@@ -2,6 +2,12 @@
 pragma solidity ^0.8.0;
 
 contract Constants {
+  // ERC1967 slots
+  bytes32 internal constant ERC1967_IMPLEMENTATION_SLOT =
+    0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+  bytes32 internal constant ERC1967_ADMIN_SLOT =
+    0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+
   // addresses expected for BGD stkAave
   address constant SHORT_EXECUTOR = 0xEE56e2B3D491590B5b31738cC34d5232F378a8D5;
   address constant STKAAVE_PROXY_ADMIN = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF;

--- a/src/test/helpers/Constants.sol
+++ b/src/test/helpers/Constants.sol
@@ -12,10 +12,6 @@ contract Constants {
   address constant SHORT_EXECUTOR = 0xEE56e2B3D491590B5b31738cC34d5232F378a8D5;
   address constant STKAAVE_PROXY_ADMIN = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF;
 
-  // admin roles for GhoToken
-  bytes32 public constant FACILITATOR_MANAGER_ROLE = keccak256('FACILITATOR_MANAGER_ROLE');
-  bytes32 public constant BUCKET_MANAGER_ROLE = keccak256('BUCKET_MANAGER_ROLE');
-
   // default admin role
   bytes32 public constant DEFAULT_ADMIN_ROLE = bytes32(0);
 

--- a/src/test/mocks/MockUpgradeable.sol
+++ b/src/test/mocks/MockUpgradeable.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {VersionedInitializable} from '@aave/core-v3/contracts/protocol/libraries/aave-upgradeability/VersionedInitializable.sol';
+import {Initializable} from 'solidity-utils/contracts/transparent-proxy/Initializable.sol';
 
 /**
  * @dev Mock contract to test upgrades, not to be used in production.
  */
-contract MockUpgradeable is VersionedInitializable {
+contract MockUpgradeable is Initializable {
   /**
    * @dev Constructor
    */
@@ -17,20 +17,7 @@ contract MockUpgradeable is VersionedInitializable {
   /**
    * @dev Initializer
    */
-  function initialize() public initializer {
+  function initialize() public reinitializer(2) {
     // Intentionally left bank
-  }
-
-  /**
-   * @notice Returns the revision number
-   * @return The revision number
-   */
-  function REVISION() public pure returns (uint256) {
-    return 2;
-  }
-
-  /// @inheritdoc VersionedInitializable
-  function getRevision() internal pure virtual override returns (uint256) {
-    return REVISION();
   }
 }

--- a/src/test/mocks/MockUpgradeable.sol
+++ b/src/test/mocks/MockUpgradeable.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {VersionedInitializable} from '@aave/core-v3/contracts/protocol/libraries/aave-upgradeability/VersionedInitializable.sol';
+
+/**
+ * @dev Mock contract to test upgrades, not to be used in production.
+ */
+contract MockUpgradeable is VersionedInitializable {
+  /**
+   * @dev Constructor
+   */
+  constructor() {
+    // Intentionally left bank
+  }
+
+  /**
+   * @dev Initializer
+   */
+  function initialize() public initializer {
+    // Intentionally left bank
+  }
+
+  /**
+   * @notice Returns the revision number
+   * @return The revision number
+   */
+  function REVISION() public pure returns (uint256) {
+    return 2;
+  }
+
+  /// @inheritdoc VersionedInitializable
+  function getRevision() internal pure virtual override returns (uint256) {
+    return REVISION();
+  }
+}


### PR DESCRIPTION
It might be preferable to use an upgradeable version of the GHO Token on chains other than Ethereum to allow for amendments if necessary.

This PR introduces an upgradeable version of the Gho Token contract. It retains the same functionality as the standard [GhoToken](https://github.com/aave/gho-core/blob/f02f87482de7ccbd30ba76b40939fb016dbb2fea/src/contracts/gho/GhoToken.sol) but includes minor adaptations to facilitate future upgrades. Notably, initializations typically performed in the constructor are now executed in the initialize function.