### PR TITLE
Fix: Check for Potential Underflow Issue Before Burning

### DIFF
--- a/src/contracts/gho/GhoToken.sol
+++ b/src/contracts/gho/GhoToken.sol
@@ -51,6 +51,9 @@ contract GhoToken is ERC20, AccessControl, IGhoToken {
 
     Facilitator storage f = _facilitators[msg.sender];
     uint256 currentBucketLevel = f.bucketLevel;
+
+    require(currentBucketLevel >= amount, 'INSUFFICIENT_FUNDS');
+
     uint256 newBucketLevel = currentBucketLevel - amount;
     f.bucketLevel = uint128(newBucketLevel);
 


### PR DESCRIPTION
If `amount` is greater than `currentBucketLevel`, the subtraction `currentBucketLevel - amount` will result in an integer underflow. In Solidity versions before 0.8.0, this would wrap around to a very large number. While Solidity 0.8.0 and later versions revert on underflow by default, the code explicitly casts the potentially underflown `newBucketLevel` to `uint128`.

Casting with `f.bucketLevel = uint128(newBucketLevel)` bypasses the underflow check. If newBucketLevel underflows, it will wrap around to a large number when cast to uint128. This leads to incorrect accounting of the facilitator's bucketLevel.