### PR TITLE
Fix: Prevent minting to the zero address

### DIFF
--- a/src/contracts/gho/ERC20.sol
+++ b/src/contracts/gho/ERC20.sol
@@ -160,6 +160,8 @@ abstract contract ERC20 is IERC20 {
     //////////////////////////////////////////////////////////////*/
 
   function _mint(address to, uint256 amount) internal virtual {
+    require(to != address(0), 'Cannot mint to the zero address');
+
     totalSupply += amount;
 
     // Cannot overflow because the sum of all user


### PR DESCRIPTION
In `_mint(address to, uint256 amount)`, there's no check to prevent minting to the zero address (`address(0)`). Minting to the zero address effectively burns tokens but without emitting a `Transfer` event to `address(0)`. Not be a critical vulnerability, but could potentially  lead to unexpected behaviour making it harder to track the total supply accurately.

This fix adds a simple `require(to != address(0), "Cannot mint to the zero address")` statement.