### PR TITLE
Update OraclaSwapFreezer Check

### DIFF
--- a/src/contracts/facilitators/gsm/swapFreezer/OracleSwapFreezer.sol
+++ b/src/contracts/facilitators/gsm/swapFreezer/OracleSwapFreezer.sol
@@ -54,7 +54,7 @@ contract OracleSwapFreezer is AutomationCompatibleInterface {
     uint128 unfreezeUpperBound,
     bool allowUnfreeze
   ) {
-    require(gsm.UNDERLYING_ASSET() == underlyingAsset, 'UNDERLYING_ASSET_MISMATCH');
+    require(underlyingAsset != address(0), 'ZERO_ADDRESS_NOT_VALID');
     require(
       _validateBounds(
         freezeLowerBound,

--- a/src/test/TestGsmOracleSwapFreezer.t.sol
+++ b/src/test/TestGsmOracleSwapFreezer.t.sol
@@ -26,8 +26,8 @@ contract TestGsmOracleSwapFreezer is TestGhoBase {
     GHO_GSM.grantRole(GSM_SWAP_FREEZER_ROLE, address(swapFreezer));
   }
 
-  function testRevertConstructorInvalidUnderlying() public {
-    vm.expectRevert('UNDERLYING_ASSET_MISMATCH');
+  function testRevertConstructorInvalidZeroAddress() public {
+    vm.expectRevert('ZERO_ADDRESS_NOT_VALID');
     new OracleSwapFreezer(
       GHO_GSM,
       address(0),


### PR DESCRIPTION
# Changelog

Update check to ensure underlying asset is not zero address, but it can differ from GSM underlying asset.
Update tests.

Closes #446 